### PR TITLE
Rename adler32 to adler32_zlib

### DIFF
--- a/lib/adler32.c
+++ b/lib/adler32.c
@@ -46,7 +46,7 @@
 #define UNROLL_FACTOR	4
 
 u32
-adler32(const void *buffer, size_t size)
+adler32_zlib(const void *buffer, size_t size)
 {
 	u32 s1 = 1;
 	u32 s2 = 0;

--- a/lib/adler32.h
+++ b/lib/adler32.h
@@ -7,6 +7,6 @@
 
 #include "common_defs.h"
 
-extern u32 adler32(const void *buffer, size_t size);
+extern u32 adler32_zlib(const void *buffer, size_t size);
 
 #endif /* _LIB_ADLER32_H */

--- a/lib/zlib_compress.c
+++ b/lib/zlib_compress.c
@@ -57,7 +57,7 @@ zlib_compress(struct deflate_compressor *c, const void *in, size_t in_size,
 	out_next += deflate_size;
 
 	/* ADLER32  */
-	put_unaligned_be32(adler32(in, in_size), out_next);
+	put_unaligned_be32(adler32_zlib(in, in_size), out_next);
 	out_next += 4;
 
 	return out_next - (u8 *)out;

--- a/lib/zlib_decompress.c
+++ b/lib/zlib_decompress.c
@@ -69,7 +69,7 @@ zlib_decompress(struct deflate_decompressor *d,
 	in_next = in_end - ZLIB_FOOTER_SIZE;
 
 	/* ADLER32  */
-	if (adler32(out, actual_out_nbytes) != get_unaligned_be32(in_next))
+	if (adler32_zlib(out, actual_out_nbytes) != get_unaligned_be32(in_next))
 		return DECOMPRESS_BAD_DATA;
 
 	return DECOMPRESS_SUCCESS;


### PR DESCRIPTION
The zlib library has an `adler32()` function. This renames the function in libdeflate to avoid conflicts if both libraries are linked. I used `adler32_zlib()` to equal the naming on `crc32_gzip()`.