### PR TITLE
Update handling of exports

### DIFF
--- a/Makefile.msc
+++ b/Makefile.msc
@@ -5,6 +5,9 @@
 #	nmake /f Makefile.msc
 #
 
+.SUFFIXES:
+.SUFFIXES: .obj .dllobj .c
+
 CC = cl
 LD = link
 AR = lib
@@ -26,6 +29,17 @@ LIB_OBJ = lib/aligned_malloc.obj	\
 	  lib/zlib_compress.obj		\
 	  lib/zlib_decompress.obj
 
+DLL_OBJ = lib/aligned_malloc.dllobj	\
+	  lib/adler32.dllobj		\
+	  lib/crc32.dllobj		\
+	  lib/deflate_compress.dllobj	\
+	  lib/deflate_decompress.dllobj	\
+	  lib/gzip_compress.dllobj	\
+	  lib/gzip_decompress.dllobj	\
+	  lib/x86_cpu_features.dllobj	\
+	  lib/zlib_compress.dllobj	\
+	  lib/zlib_decompress.dllobj
+
 PROG_COMMON_OBJ = programs/prog_util.obj \
 		  programs/tgetopt.obj \
 		  $(STATICLIB)
@@ -37,11 +51,14 @@ all: $(STATICLIB) $(SHAREDLIB) $(IMPLIB) gzip.exe gunzip.exe
 .c.obj:
 	$(CC) -c /Fo$@ $(CFLAGS) $**
 
+.c.dllobj:
+	$(CC) -c /Fo$@ $(CFLAGS) /DLIBDEFLATE_DLL $**
+
 $(STATICLIB): $(LIB_OBJ)
 	$(AR) $(ARFLAGS) -out:$@ $(LIB_OBJ)
 
-$(SHAREDLIB): $(LIB_OBJ)
-	$(LD) $(LDFLAGS) -out:$@ -dll -implib:$(IMPLIB) $(LIB_OBJ)
+$(SHAREDLIB): $(DLL_OBJ)
+	$(LD) $(LDFLAGS) -out:$@ -dll -implib:$(IMPLIB) $(DLL_OBJ)
 
 $(IMPLIB): $(SHAREDLIB)
 
@@ -53,4 +70,4 @@ gunzip.exe:gzip.exe
 
 clean:
 	-del *.dll *.exe *.exp libdeflate.lib libdeflatestatic.lib gzip.lib \
-		lib\*.obj programs\*.obj 2>nul
+		lib\*.obj lib\*.dllobj programs\*.obj 2>nul

--- a/common/common_defs.h
+++ b/common/common_defs.h
@@ -28,6 +28,8 @@
 #ifndef COMMON_COMMON_DEFS_H
 #define COMMON_COMMON_DEFS_H
 
+#define BUILDING_LIBDEFLATE
+
 #ifdef __GNUC__
 #  include "compiler_gcc.h"
 #elif defined(_MSC_VER)

--- a/common/compiler_gcc.h
+++ b/common/compiler_gcc.h
@@ -18,12 +18,6 @@
 #  define __has_builtin(builtin)	0
 #endif
 
-#ifdef _WIN32
-#  define LIBEXPORT __declspec(dllexport)
-#else
-#  define LIBEXPORT __attribute__((visibility("default")))
-#endif
-
 #define inline			inline
 #define forceinline		inline __attribute__((always_inline))
 #define restrict		__restrict__

--- a/common/compiler_msc.h
+++ b/common/compiler_msc.h
@@ -2,10 +2,6 @@
  * compiler_msc.h - definitions for the Microsoft C Compiler
  */
 
-#define BUILDING_LIBDEFLATE
-
-#define LIBEXPORT	__declspec(dllexport)
-
 /*
  * Old versions (e.g. VS2010) of MSC don't have the C99 header stdbool.h.
  * Beware: the below replacement isn't fully standard, since normally any value

--- a/libdeflate.h
+++ b/libdeflate.h
@@ -17,15 +17,22 @@ extern "C" {
 
 /* Microsoft C / Visual Studio garbage.  If you want to link to the DLL version
  * of libdeflate, then #define LIBDEFLATE_DLL.  */
-#ifdef _MSC_VER
-#  ifdef BUILDING_LIBDEFLATE
-#    define LIBDEFLATEAPI __declspec(dllexport)
-#  elif defined(LIBDEFLATE_DLL)
-#    define LIBDEFLATEAPI __declspec(dllimport)
+#if defined(LIBDEFLATE_DLL)
+#  if defined(_WIN32) || defined(__CYGWIN__)
+#    if defined(BUILDING_LIBDEFLATE)
+#      define LIBDEFLATEAPI __declspec(dllexport)
+#    else
+#      define LIBDEFLATEAPI __declspec(dllimport)
+#    endif
 #  endif
 #endif
-#ifndef LIBDEFLATEAPI
-#  define LIBDEFLATEAPI
+
+#if !defined(LIBDEFLATEAPI)
+#  if defined(__GNUC__) && __GNUC__ >= 4
+#    define LIBDEFLATEAPI __attribute__((visibility("default")))
+#  else
+#    define LIBDEFLATEAPI
+#  endif
 #endif
 
 /* ========================================================================== */


### PR DESCRIPTION
When compiling libdeflate on Windows, the public functions are declared dllexport. This results in executables that are linked with libdeflate also exporting these functions.

This is an attempt to fix this, and gather the export handling in the main header. I don't know if you prefer some other way to fix this though.