### PR TITLE
Set UNALIGNED_ACCESS_IS_FAST on powerpc64

### DIFF
--- a/common/compiler_gcc.h
+++ b/common/compiler_gcc.h
@@ -123,7 +123,7 @@
 #  define bswap64	__builtin_bswap64
 #endif
 
-#if defined(__x86_64__) || defined(__i386__) || defined(__ARM_FEATURE_UNALIGNED)
+#if defined(__x86_64__) || defined(__i386__) || defined(__ARM_FEATURE_UNALIGNED) || defined(__powerpc64__)
 #  define UNALIGNED_ACCESS_IS_FAST 1
 #endif
 


### PR DESCRIPTION
All 64bit PowerPC CPUs handle unaligned accesses reasonably fast, so
set UNALIGNED_ACCESS_IS_FAST.

Decompression of the snappy html test case is almost 50% faster on
POWER9 with this patch applied.