### PR TITLE
ARM: NEON is not available with the FPU emulation

### DIFF
--- a/common/compiler_gcc.h
+++ b/common/compiler_gcc.h
@@ -86,7 +86,7 @@
 #      define COMPILER_SUPPORTS_AVX2_TARGET_INTRINSICS	\
 		COMPILER_SUPPORTS_AVX2_TARGET
 #    endif
-#  elif defined(__arm__) || defined(__aarch64__)
+#  elif (defined(__arm__) && !defined(__SOFTFP__)) || defined(__aarch64__)
 	/*
 	 * Prior to gcc 6.1 (r230411 for arm, r226563 for aarch64), NEON
 	 * and crypto intrinsics not available in the main target could not be


### PR DESCRIPTION
NEON code cannot even be compiled when using the FPU emulation
for older ARM chips (like in the Debian armel port).

https://buildd.debian.org/status/fetch.php?pkg=libdeflate&arch=armel&ver=1.0-2&stamp=1544176531&raw=0