### PR TITLE
Include stdlib.h for _byteswap_* on MSVC.

### DIFF
--- a/common/compiler_msc.h
+++ b/common/compiler_msc.h
@@ -52,6 +52,7 @@ typedef int ssize_t;
 #define forceinline	__forceinline
 
 /* Byte swap functions */
+#include <stdlib.h>
 #define bswap16	_byteswap_ushort
 #define bswap32	_byteswap_ulong
 #define bswap64	_byteswap_uint64


### PR DESCRIPTION
This fixes error C4013 ('_byteswap_ulong' undefined; assuming extern returning int) in crc32.c.