### PR TITLE
Solution for issue #30

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+Version 1.3:
+	Activate -n switch in gzip program
+
+	Add file_name parameter to libdeflate_gzip_compress function. This
+	function store filename in gz if file_name parameter in not null.
+	
 Version 1.2:
 	Slight improvements to decompression speed.
 

--- a/libdeflate.h
+++ b/libdeflate.h
@@ -128,7 +128,7 @@ LIBDEFLATEAPI size_t
 libdeflate_zlib_compress_bound(struct libdeflate_compressor *compressor,
 			       size_t in_nbytes);
 
-/*
+ /*
  * Like libdeflate_deflate_compress(), but stores the data in the gzip wrapper
  * format.
  */
@@ -137,6 +137,16 @@ libdeflate_gzip_compress(struct libdeflate_compressor *compressor,
 			 const void *in, size_t in_nbytes,
 			 void *out, size_t out_nbytes_avail);
 
+/*
+ * Like libdeflate_gzip_compress(), but stores the filename
+ * format.
+ */
+LIBDEFLATEAPI size_t
+libdeflate_gzip_compress_ex(struct libdeflate_compressor *compressor,
+			 const void *in, size_t in_nbytes,
+			 void *out, size_t out_nbytes_avail,
+			 char *file_name);
+ 
 /*
  * Like libdeflate_deflate_compress_bound(), but assumes the data will be
  * compressed with libdeflate_gzip_compress() rather than with


### PR DESCRIPTION
Activate -N switch.
Optional store filename in GZ

Create a new function libdeflate_gzip_compress_ex for preserve compatibility. The old function libdeflate_gzip_compress have the same parameters thet the previous version.