### PR TITLE
Building dylib on MacOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.a
 *.dll
+*.dylib
 *.exe
 *.exp
 *.lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+language: c
+
+matrix:
+  include:
+    - os: linux
+      compiler: gcc
+    - os: linux
+      compiler: clang
+    - os: linux
+      dist: trusty
+      compiler: gcc
+    - os: linux
+      dist: trusty
+      compiler: clang
+    - os: osx
+      compiler: clang
+      osx_image: xcode11
+    - os: osx
+      compiler: clang
+      osx_image: xcode9.4
+    - os: osx
+      compiler: clang
+      osx_image: xcode7.3
+    - os: windows
+      env:
+        MAKE=mingw32-make
+
+env:
+  global:
+      MAKE=make
+script:
+  - $MAKE all test_programs && cat benchmark | ./benchmark &&  ./test_slow_decompression

--- a/Makefile
+++ b/Makefile
@@ -95,8 +95,7 @@ else ifeq ($(shell uname),Darwin)
    SHARED_LIB_SUFFIX  := .dylib
    SHARED_LIB          = libdeflate$(SOVERSION)$(SHARED_LIB_SUFFIX)
    SHARED_LIB_LDFLAGS := "-install_name $(SHARED_LIB)"
-   AR                 := libtool
-   ARFLAGS            := -static -o
+   ARFLAGS            += --target mach-o-x86-64
    ARCHS              := x86
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,6 @@ SHARED_LIB_LDFLAGS := -Wl,-soname=$(SHARED_LIB)
 PROG_SUFFIX        :=
 PROG_CFLAGS        :=
 HARD_LINKS         := 1
-ARFLAGS            := cr
-ARCHS              := *
 
 # Compiling for Windows with MinGW?
 ifneq ($(findstring -mingw,$(shell $(CC) -dumpmachine 2>/dev/null)),)
@@ -94,7 +92,7 @@ ifneq ($(findstring -mingw,$(shell $(CC) -dumpmachine 2>/dev/null)),)
 else ifeq ($(shell uname),Darwin)
    SHARED_LIB_SUFFIX  := .dylib
    SHARED_LIB          = libdeflate$(SOVERSION)$(SHARED_LIB_SUFFIX)
-   SHARED_LIB_LDFLAGS := "-install_name $(SHARED_LIB)"
+   SHARED_LIB_LDFLAGS := -install_name $(SHARED_LIB)
 endif
 
 ##############################################################################
@@ -126,7 +124,7 @@ LIB_CFLAGS += $(CFLAGS) -fvisibility=hidden -D_ANSI_SOURCE
 LIB_HEADERS := $(wildcard lib/*.h) $(wildcard lib/*/*.h)
 
 LIB_SRC := lib/aligned_malloc.c lib/deflate_decompress.c \
-	   $(wildcard lib/$(ARCHS)/cpu_features.c)
+	   $(wildcard lib/*/cpu_features.c)
 
 DECOMPRESSION_ONLY :=
 ifndef DECOMPRESSION_ONLY
@@ -163,7 +161,7 @@ $(SHARED_LIB_OBJ): %.shlib.o: %.c $(LIB_HEADERS) $(COMMON_HEADERS) .lib-cflags
 
 # Create static library
 $(STATIC_LIB):$(STATIC_LIB_OBJ)
-	$(QUIET_AR) $(AR) $(ARFLAGS) $@ $+
+	$(QUIET_AR) $(AR) cr $@ $+
 
 DEFAULT_TARGETS += $(STATIC_LIB)
 

--- a/Makefile
+++ b/Makefile
@@ -95,8 +95,6 @@ else ifeq ($(shell uname),Darwin)
    SHARED_LIB_SUFFIX  := .dylib
    SHARED_LIB          = libdeflate$(SOVERSION)$(SHARED_LIB_SUFFIX)
    SHARED_LIB_LDFLAGS := "-install_name $(SHARED_LIB)"
-   ARFLAGS            += --target mach-o-x86-64
-   ARCHS              := x86
 endif
 
 ##############################################################################

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.com/ebiggers/libdeflate.svg?branch=master)](https://travis-ci.com/ebiggers/libdeflate)
+
 # Overview
 
 libdeflate is a library for fast, whole-buffer DEFLATE-based compression and


### PR DESCRIPTION
@ebiggers you mentioned no way to test MacOS, this PR adds configuration for [Travis-CI](http://travis-ci.com/) so it's tested there.

@epruesse hope you don't mind. 

I've rebased against master, enabled travis, included a badge, and resolved a minor issue with passing the linker option `-install_name`

## References

* #43
* fc944d7 [build status](https://travis-ci.com/kiwiroy/libdeflate/builds/123494945)
* 32aea94 [build status](https://travis-ci.com/kiwiroy/libdeflate/builds/123489892) which enabled travis off master
*  **Edit:** windows too now with 6df90ff