### PR TITLE
Use Cirrus CI to test FreeBSD

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,9 @@
+task:
+  freebsd_instance:
+    matrix:
+      - image: freebsd-11-2-release-amd64
+      - image: freebsd-12-0-release-amd64
+  install_script: pkg install -y gmake
+  script:
+    - gmake all test_programs && cat benchmark | ./benchmark &&  ./test_slow_decompression
+  


### PR DESCRIPTION
Enable integration testing of FreeBSD in addition to linux and macos on travis.