### PR TITLE
Fix clean task in Makefile.msc

### DIFF
--- a/Makefile.msc
+++ b/Makefile.msc
@@ -60,6 +60,6 @@ gunzip.exe:gzip.exe
 	copy $** $@
 
 clean:
-	-del *.dll *.exe *.exp libdeflate.lib libdeflatestatic.lib gzip.lib \
-		lib\*.obj lib\*\*.obj lib\*.dllobj lib\*\*.dllobj \
-		programs\*.obj 2>nul
+	-del /s /q *.dll *.exe *.exp libdeflate.lib libdeflatestatic.lib gzip.lib \
+		lib\*.obj lib\*.dllobj \
+		programs\*.obj >nul 2>&1


### PR DESCRIPTION
See https://superuser.com/q/1124790

Quoted from question:

> And here's the problem: next step I do:
> ```
> del /s "*\*.tmp" 
> ```
> but got the error: The filename, directory name, or volume label syntax is incorrect.

From answer:

> The DEL command in your example should be in this syntax:
>
> - `DEL /Q /F /S "*.tmp"`
>
> Essentially you don't need to try to wildcard any folder paths and the `/S` switch is used to **delete specified files from all subdirectories** from the directory you are in when you run the command and all the way down recursively from all beneath subfolders.

From [SS64 page on DEL](http://ss64.com/nt/del.html):

> options:
> &emsp;/P  Give a Yes/No Prompt before deleting.
> &emsp;/F  Ignore read-only setting and delete anyway (FORCE)
> &emsp;/S  Delete from all Subfolders (DELTREE)
> &emsp;/Q  Quiet mode, do not give a Yes/No Prompt before deleting.