### PR TITLE
Fixup -D FREESTANDING on MSVC

### DIFF
--- a/common/compiler_msc.h
+++ b/common/compiler_msc.h
@@ -3,7 +3,7 @@
  */
 
 #include <stdint.h>
-#include <stddef.h> /* for _byteswap_*() */
+#include <stdlib.h> /* for _byteswap_*() */
 
 #define LIBEXPORT	__declspec(dllexport)
 

--- a/common/compiler_msc.h
+++ b/common/compiler_msc.h
@@ -3,7 +3,7 @@
  */
 
 #include <stdint.h>
-#include <stdlib.h> /* for _byteswap_*() */
+#include <stddef.h> /* for _byteswap_*() */
 
 #define LIBEXPORT	__declspec(dllexport)
 

--- a/lib/lib_common.h
+++ b/lib/lib_common.h
@@ -36,7 +36,7 @@ void libdeflate_free(void *ptr);
 void *libdeflate_aligned_malloc(size_t alignment, size_t size);
 void libdeflate_aligned_free(void *ptr);
 
-#ifdef FREESTANDING
+#if defined(FREESTANDING) && !defined(_MSC_VER)
 /*
  * With -ffreestanding, <string.h> may be missing, and we must provide
  * implementations of memset(), memcpy(), memmove(), and memcmp().

--- a/lib/utils.c
+++ b/lib/utils.c
@@ -25,14 +25,14 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include "lib_common.h"
+
 #ifdef FREESTANDING
 #  define malloc NULL
 #  define free NULL
 #else
 #  include <stdlib.h>
 #endif
-
-#include "lib_common.h"
 
 #include "libdeflate.h"
 


### PR DESCRIPTION
MSVC doesn't have an option for proper freestanding support, but there's no reason why compilation with this flag should completely fail.

Before this change, the `#define malloc NULL` and `#define free NULL` were followed by `#include <stdlib.h>` and conflicted with real declarations, resulting in weird syntax errors.

Note that this issue didn't occur in the original commit - https://github.com/RReverser/libdeflate/commit/7c7fed4b384dda1e54101229a258694a89bad735 - but, looks like it was modified upon merge from `stddef.h` to `stdlib.h` here https://github.com/ebiggers/libdeflate/commit/e2d1621e421e4a65bfe04d7f2687445612f91654. Judging from the description, this was done for backward compatibility with old MSVC?

Anyway, this PR fixes the issue, while keeping the `stdlib.h` include, by simply reordering custom definitions to appear after the standard ones.

Additionally, it changes conditional block on the recently introduced `__builtin_mem*` functions to use regular `mem*` functions in case -D FREESTANDING is used on MSVC, because the latter doesn't have `__builtin_mem*`s.

In the end, the `-D FREESTANDING` compiles on MSVC without issues again, but the only actual effect it has is changing default allocator functions to `NULL`.

This is still useful for cross-platform compatibility of builds with same flags.