### PR TITLE
Add arm64 jobs to Travis build matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,24 @@ matrix:
       script:
         - tools/run_tests.sh checksum_benchmarks static_analysis edge_case
 
+    - name: Native tests (Linux aarch64)
+      os: linux
+      dist: bionic
+      arch: arm64
+      before_install:
+        - sudo apt-get install -y libz-dev valgrind clang
+      script:
+        - tools/run_tests.sh native freestanding
+
+    - name: Checksum, static analysis, and edge case tests (Linux aarch64)
+      os: linux
+      dist: bionic
+      arch: arm64
+      before_install:
+        - sudo apt-get install -y libz-dev clang python3
+      script:
+        - tools/run_tests.sh checksum_benchmarks static_analysis edge_case
+
     - name: gzip and cross-compile-for-Windows tests (Linux)
       os: linux
       dist: bionic


### PR DESCRIPTION
Travis CI [recently added support for building builds on 64-bit Arm using AWS Graviton2 instances](https://blog.travis-ci.com/2020-09-11-arm-on-aws). I felt obliged to add it so that Arm support does not bit-rot due to a lack of CI testing.