### PR TITLE
Improve architecture-specific matchfinder code.

### DIFF
--- a/lib/x86/matchfinder_impl.h
+++ b/lib/x86/matchfinder_impl.h
@@ -111,7 +111,7 @@ matchfinder_rebase_avx2(mf_pos_t *data, size_t size)
 #    define DISPATCH					1
 #  endif
 #  define DISPATCH_MATCHFINDER_SSE2	1
-#  define DISPATCH		1
+#  define DISPATCH					1
 #  include <emmintrin.h>
 static forceinline ATTRIBUTES bool
 matchfinder_init_sse2(mf_pos_t *data, size_t size)


### PR DESCRIPTION
This PR improves the architecture-specific matchfinder by adding dynamic dispatch, ala the existing Adler-32 and CRC32 paths. The primary goal is to allow more matchfinders to be added and improve performance somewhat.

The main impact is on x86: the AVX2 matchfinder can now be properly dynamically dispatched at runtime and if `-mavx2` is included in `CFLAGS` (or `-march` set to any platform with AVX2 support). On my Ryzen 9 3900X, I got an approximately 1% boost in deflate time (measured with a uncompressed tarball of the Silesia corpus) using just the changes in this PR and the regular CFLAGS, and a 2.7% boost when specifying `-mavx2` as `CFLAGS`. (I also tested with an Intel Xeon Skylake c5.large EC2 instance, and did not see any performance regression).