### PR TITLE
lib/utils.c: improve header include order

### DIFF
--- a/lib/utils.c
+++ b/lib/utils.c
@@ -25,16 +25,16 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include "lib_common.h"
+
+#include "libdeflate.h"
+
 #ifdef FREESTANDING
 #  define malloc NULL
 #  define free NULL
 #else
 #  include <stdlib.h>
 #endif
-
-#include "lib_common.h"
-
-#include "libdeflate.h"
 
 static void *(*libdeflate_malloc_func)(size_t) = malloc;
 static void (*libdeflate_free_func)(void *) = free;


### PR DESCRIPTION
Don't assume that lib_common.h and libdeflate.h don't include
<stdlib.h>.  Currently this change doesn't matter unless someone uses
-DFREESTANDING for a Windows build, which isn't supported anyway, but we
might as well clean this up.

Update https://github.com/ebiggers/libdeflate/pull/68