### PR TITLE
lib/x86/cpu_features: add missing earlyclobber constraint for cpuid on i386

### DIFF
--- a/lib/x86/cpu_features.c
+++ b/lib/x86/cpu_features.c
@@ -34,7 +34,7 @@ volatile u32 _cpu_features = 0;
 /* With old GCC versions we have to manually save and restore the x86_32 PIC
  * register (ebx).  See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47602  */
 #if defined(__i386__) && defined(__PIC__)
-#  define EBX_CONSTRAINT "=r"
+#  define EBX_CONSTRAINT "=&r"
 #else
 #  define EBX_CONSTRAINT "=b"
 #endif


### PR DESCRIPTION
In cpuid() in the '__i386__ && __PIC__' case, the second output operand
is written to before the input operands are used.  So the second output
operand needs the earlyclobber constraint.