### PR TITLE
Support level 0, "no compression"

### DIFF
--- a/libdeflate.h
+++ b/libdeflate.h
@@ -61,9 +61,12 @@ struct libdeflate_compressor;
  * libdeflate_alloc_compressor() allocates a new compressor that supports
  * DEFLATE, zlib, and gzip compression.  'compression_level' is the compression
  * level on a zlib-like scale but with a higher maximum value (1 = fastest, 6 =
- * medium/default, 9 = slow, 12 = slowest).  The return value is a pointer to
- * the new compressor, or NULL if out of memory or if the compression level is
- * invalid (i.e. outside the range [1, 12]).
+ * medium/default, 9 = slow, 12 = slowest).  Level 0 is also supported and means
+ * "no compression", specifically "create a valid stream, but only emit
+ * uncompressed blocks" (this will expand the data slightly).
+ *
+ * The return value is a pointer to the new compressor, or NULL if out of memory
+ * or if the compression level is invalid (i.e. outside the range [0, 12]).
  *
  * Note: for compression, the sliding window size is defined at compilation time
  * to 32768, the largest size permissible in the DEFLATE format.  It cannot be

--- a/programs/gzip.c
+++ b/programs/gzip.c
@@ -550,7 +550,7 @@ tmain(int argc, tchar *argv[])
 		case '9':
 			options.compression_level =
 				parse_compression_level(opt_char, toptarg);
-			if (options.compression_level == 0)
+			if (options.compression_level < 0)
 				return 1;
 			break;
 		case 'c':

--- a/programs/test_custom_malloc.c
+++ b/programs/test_custom_malloc.c
@@ -43,7 +43,7 @@ tmain(int argc, tchar *argv[])
 	ASSERT(malloc_count == 0);
 	ASSERT(free_count == 0);
 
-	for (level = 1; level <= 12; level++) {
+	for (level = 0; level <= 12; level++) {
 		malloc_count = free_count = 0;
 		c = libdeflate_alloc_compressor(level);
 		ASSERT(c != NULL);
@@ -67,7 +67,7 @@ tmain(int argc, tchar *argv[])
 
 	libdeflate_set_memory_allocator(do_fail_malloc, do_free);
 
-	for (level = 1; level <= 12; level++) {
+	for (level = 0; level <= 12; level++) {
 		malloc_count = free_count = 0;
 		c = libdeflate_alloc_compressor(level);
 		ASSERT(c == NULL);

--- a/tools/exec_tests.sh
+++ b/tools/exec_tests.sh
@@ -18,12 +18,12 @@ for format in '' '-g' '-z'; do
 		run_cmd ./benchmark $format $ref_impl $SMOKEDATA
 	done
 done
-for level in 1 3 7 9; do
+for level in 0 1 3 7 9; do
 	for ref_impl in '' '-Y'; do
 		run_cmd ./benchmark -$level $ref_impl $SMOKEDATA
 	done
 done
-for level in 1 3 7 9 12; do
+for level in 0 1 3 7 9 12; do
 	for ref_impl in '' '-Z'; do
 		run_cmd ./benchmark -$level $ref_impl $SMOKEDATA
 	done


### PR DESCRIPTION
Some users may require a valid DEFLATE, zlib, or gzip stream but know
ahead of time that particular inputs are not compressible.  zlib
supports "level 0" for this use case.  Support this in libdeflate too.

Resolves https://github.com/ebiggers/libdeflate/issues/86