### PR TITLE
programs: rename program_invocation_name to prog_invocation_name

### DIFF
--- a/programs/benchmark.c
+++ b/programs/benchmark.c
@@ -406,7 +406,7 @@ show_usage(FILE *fp)
 "  -s SIZE   chunk size\n"
 "  -V        show version and legal information\n"
 "  -z        use zlib wrapper\n"
-"\n", program_invocation_name);
+"\n", prog_invocation_name);
 
 	show_available_engines(fp);
 }

--- a/programs/checksum.c
+++ b/programs/checksum.c
@@ -42,7 +42,7 @@ show_usage(FILE *fp)
 "  -s SIZE   chunk size\n"
 "  -t        show checksum speed, excluding I/O\n"
 "  -Z        use zlib implementation instead of libdeflate\n",
-	program_invocation_name);
+	prog_invocation_name);
 }
 
 typedef u32 (*cksum_fn_t)(u32, const void *, size_t);

--- a/programs/gzip.c
+++ b/programs/gzip.c
@@ -67,7 +67,7 @@ show_usage(FILE *fp)
 "  -k        don't delete input files\n"
 "  -S SUF    use suffix SUF instead of .gz\n"
 "  -V        show version and legal information\n",
-	program_invocation_name);
+	prog_invocation_name);
 }
 
 static void
@@ -87,14 +87,14 @@ show_version(void)
 static bool
 is_gunzip(void)
 {
-	if (tstrxcmp(program_invocation_name, T("gunzip")) == 0)
+	if (tstrxcmp(prog_invocation_name, T("gunzip")) == 0)
 		return true;
-	if (tstrxcmp(program_invocation_name, T("libdeflate-gunzip")) == 0)
+	if (tstrxcmp(prog_invocation_name, T("libdeflate-gunzip")) == 0)
 		return true;
 #ifdef _WIN32
-	if (tstrxcmp(program_invocation_name, T("gunzip.exe")) == 0)
+	if (tstrxcmp(prog_invocation_name, T("gunzip.exe")) == 0)
 		return true;
-	if (tstrxcmp(program_invocation_name, T("libdeflate-gunzip.exe")) == 0)
+	if (tstrxcmp(prog_invocation_name, T("libdeflate-gunzip.exe")) == 0)
 		return true;
 #endif
 	return false;

--- a/programs/prog_util.c
+++ b/programs/prog_util.c
@@ -54,14 +54,14 @@
 #endif
 
 /* The invocation name of the program (filename component only) */
-const tchar *program_invocation_name;
+const tchar *prog_invocation_name;
 
 static void
 do_msg(const char *format, bool with_errno, va_list va)
 {
 	int saved_errno = errno;
 
-	fprintf(stderr, "%"TS": ", program_invocation_name);
+	fprintf(stderr, "%"TS": ", prog_invocation_name);
 	vfprintf(stderr, format, va);
 	if (with_errno)
 		fprintf(stderr, ": %s\n", strerror(saved_errno));
@@ -129,7 +129,7 @@ get_filename(const tchar *path)
 void
 begin_program(tchar *argv[])
 {
-	program_invocation_name = get_filename(argv[0]);
+	prog_invocation_name = get_filename(argv[0]);
 
 #ifdef FREESTANDING
 	/* This allows testing freestanding library builds. */
@@ -233,7 +233,7 @@ retry:
 			}
 			fprintf(stderr, "%"TS": %"TS" already exists; "
 				"overwrite? (y/n) ",
-				program_invocation_name, strm->name);
+				prog_invocation_name, strm->name);
 			if (getchar() != 'y') {
 				msg("Not overwriting.");
 				goto err;

--- a/programs/prog_util.h
+++ b/programs/prog_util.h
@@ -133,7 +133,7 @@ int wmain(int argc, wchar_t **argv);
 
 #endif /* !_WIN32 */
 
-extern const tchar *program_invocation_name;
+extern const tchar *prog_invocation_name;
 
 void _printf(1, 2) msg(const char *fmt, ...);
 void _printf(1, 2) msg_errno(const char *fmt, ...);


### PR DESCRIPTION
Avoid confusion with the GNU extension 'program_invocation_name', which
is described by 'man 3 program_invocation_name'.  The GNU version isn't
supposed to be exposed without defining _GNU_SOURCE, which we don't in
any of the relevant files, but it's best to avoid any confusion.