### PR TITLE
Makefile: add missing settings to rebuild logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,7 @@
 *.obj
 *.so
 *.so.*
-/.lib-cflags
-/.prog-cflags
+/.build-config
 /programs/config.h
 /benchmark
 /checksum


### PR DESCRIPTION
The Makefile didn't trigger a rebuild if some settings changed, e.g.
LDFLAGS or DECOMPRESSION_ONLY.  Fix this.

Also simplify the rebuild logic by not handling the library and programs
separately, as this optimization doesn't seem to be worthwhile.