### PR TITLE
lib/matchfinder: simplify init and rebase

### DIFF
--- a/lib/deflate_compress.c
+++ b/lib/deflate_compress.c
@@ -2704,7 +2704,7 @@ libdeflate_alloc_compressor(int compression_level)
 		size += sizeof(c->p.g);
 #endif
 
-	c = libdeflate_aligned_malloc(MATCHFINDER_ALIGNMENT, size);
+	c = libdeflate_aligned_malloc(MATCHFINDER_MEM_ALIGNMENT, size);
 	if (!c)
 		return NULL;
 

--- a/lib/hc_matchfinder.h
+++ b/lib/hc_matchfinder.h
@@ -111,9 +111,9 @@
 #define HC_MATCHFINDER_HASH3_ORDER	15
 #define HC_MATCHFINDER_HASH4_ORDER	16
 
-#define HC_MATCHFINDER_TOTAL_HASH_LENGTH		\
-	((1UL << HC_MATCHFINDER_HASH3_ORDER) +		\
-	 (1UL << HC_MATCHFINDER_HASH4_ORDER))
+#define HC_MATCHFINDER_TOTAL_HASH_SIZE			\
+	(((1UL << HC_MATCHFINDER_HASH3_ORDER) +		\
+	  (1UL << HC_MATCHFINDER_HASH4_ORDER)) * sizeof(mf_pos_t))
 
 struct hc_matchfinder {
 
@@ -130,7 +130,7 @@ struct hc_matchfinder {
 
 }
 #ifdef _aligned_attribute
-  _aligned_attribute(MATCHFINDER_ALIGNMENT)
+  _aligned_attribute(MATCHFINDER_MEM_ALIGNMENT)
 #endif
 ;
 
@@ -138,14 +138,18 @@ struct hc_matchfinder {
 static forceinline void
 hc_matchfinder_init(struct hc_matchfinder *mf)
 {
-	matchfinder_init((mf_pos_t *)mf, HC_MATCHFINDER_TOTAL_HASH_LENGTH);
+	STATIC_ASSERT(HC_MATCHFINDER_TOTAL_HASH_SIZE %
+		      MATCHFINDER_SIZE_ALIGNMENT == 0);
+
+	matchfinder_init((mf_pos_t *)mf, HC_MATCHFINDER_TOTAL_HASH_SIZE);
 }
 
 static forceinline void
 hc_matchfinder_slide_window(struct hc_matchfinder *mf)
 {
-	matchfinder_rebase((mf_pos_t *)mf,
-			   sizeof(struct hc_matchfinder) / sizeof(mf_pos_t));
+	STATIC_ASSERT(sizeof(*mf) % MATCHFINDER_SIZE_ALIGNMENT == 0);
+
+	matchfinder_rebase((mf_pos_t *)mf, sizeof(*mf));
 }
 
 /*

--- a/lib/x86/matchfinder_impl.h
+++ b/lib/x86/matchfinder_impl.h
@@ -26,47 +26,38 @@
  */
 
 #ifdef __AVX2__
-#  if MATCHFINDER_ALIGNMENT < 32
-#    undef MATCHFINDER_ALIGNMENT
-#    define MATCHFINDER_ALIGNMENT 32
-#  endif
 #  include <immintrin.h>
-static forceinline bool
+static forceinline void
 matchfinder_init_avx2(mf_pos_t *data, size_t size)
 {
-	__m256i v, *p;
-	size_t n;
+	__m256i *p = (__m256i *)data;
+	__m256i v = _mm256_set1_epi16(MATCHFINDER_INITVAL);
 
-	if (size % (sizeof(__m256i) * 4) != 0)
-		return false;
-
+	STATIC_ASSERT(MATCHFINDER_MEM_ALIGNMENT % sizeof(*p) == 0);
+	STATIC_ASSERT(MATCHFINDER_SIZE_ALIGNMENT % (4 * sizeof(*p)) == 0);
 	STATIC_ASSERT(sizeof(mf_pos_t) == 2);
-	v = _mm256_set1_epi16(MATCHFINDER_INITVAL);
-	p = (__m256i *)data;
-	n = size / (sizeof(__m256i) * 4);
+
 	do {
 		p[0] = v;
 		p[1] = v;
 		p[2] = v;
 		p[3] = v;
 		p += 4;
-	} while (--n);
-	return true;
+		size -= 4 * sizeof(*p);
+	} while (size != 0);
 }
+#define matchfinder_init matchfinder_init_avx2
 
-static forceinline bool
+static forceinline void
 matchfinder_rebase_avx2(mf_pos_t *data, size_t size)
 {
-	__m256i v, *p;
-	size_t n;
+	__m256i *p = (__m256i *)data;
+	__m256i v = _mm256_set1_epi16((u16)-MATCHFINDER_WINDOW_SIZE);
 
-	if (size % (sizeof(__m256i) * 4) != 0)
-		return false;
-
+	STATIC_ASSERT(MATCHFINDER_MEM_ALIGNMENT % sizeof(*p) == 0);
+	STATIC_ASSERT(MATCHFINDER_SIZE_ALIGNMENT % (4 * sizeof(*p)) == 0);
 	STATIC_ASSERT(sizeof(mf_pos_t) == 2);
-	v = _mm256_set1_epi16((u16)-MATCHFINDER_WINDOW_SIZE);
-	p = (__m256i *)data;
-	n = size / (sizeof(__m256i) * 4);
+
 	do {
 		/* PADDSW: Add Packed Signed Integers With Signed Saturation  */
 		p[0] = _mm256_adds_epi16(p[0], v);
@@ -74,53 +65,44 @@ matchfinder_rebase_avx2(mf_pos_t *data, size_t size)
 		p[2] = _mm256_adds_epi16(p[2], v);
 		p[3] = _mm256_adds_epi16(p[3], v);
 		p += 4;
-	} while (--n);
-	return true;
+		size -= 4 * sizeof(*p);
+	} while (size != 0);
 }
-#endif /* __AVX2__ */
+#define matchfinder_rebase matchfinder_rebase_avx2
 
-#ifdef __SSE2__
-#  if MATCHFINDER_ALIGNMENT < 16
-#    undef MATCHFINDER_ALIGNMENT
-#    define MATCHFINDER_ALIGNMENT 16
-#  endif
+#elif defined(__SSE2__)
 #  include <emmintrin.h>
-static forceinline bool
+static forceinline void
 matchfinder_init_sse2(mf_pos_t *data, size_t size)
 {
-	__m128i v, *p;
-	size_t n;
+	__m128i *p = (__m128i *)data;
+	__m128i v = _mm_set1_epi16(MATCHFINDER_INITVAL);
 
-	if (size % (sizeof(__m128i) * 4) != 0)
-		return false;
-
+	STATIC_ASSERT(MATCHFINDER_MEM_ALIGNMENT % sizeof(*p) == 0);
+	STATIC_ASSERT(MATCHFINDER_SIZE_ALIGNMENT % (4 * sizeof(*p)) == 0);
 	STATIC_ASSERT(sizeof(mf_pos_t) == 2);
-	v = _mm_set1_epi16(MATCHFINDER_INITVAL);
-	p = (__m128i *)data;
-	n = size / (sizeof(__m128i) * 4);
+
 	do {
 		p[0] = v;
 		p[1] = v;
 		p[2] = v;
 		p[3] = v;
 		p += 4;
-	} while (--n);
-	return true;
+		size -= 4 * sizeof(*p);
+	} while (size != 0);
 }
+#define matchfinder_init matchfinder_init_sse2
 
-static forceinline bool
+static forceinline void
 matchfinder_rebase_sse2(mf_pos_t *data, size_t size)
 {
-	__m128i v, *p;
-	size_t n;
+	__m128i *p = (__m128i *)data;
+	__m128i v = _mm_set1_epi16((u16)-MATCHFINDER_WINDOW_SIZE);
 
-	if (size % (sizeof(__m128i) * 4) != 0)
-		return false;
-
+	STATIC_ASSERT(MATCHFINDER_MEM_ALIGNMENT % sizeof(*p) == 0);
+	STATIC_ASSERT(MATCHFINDER_SIZE_ALIGNMENT % (4 * sizeof(*p)) == 0);
 	STATIC_ASSERT(sizeof(mf_pos_t) == 2);
-	v = _mm_set1_epi16((u16)-MATCHFINDER_WINDOW_SIZE);
-	p = (__m128i *)data;
-	n = size / (sizeof(__m128i) * 4);
+
 	do {
 		/* PADDSW: Add Packed Signed Integers With Signed Saturation  */
 		p[0] = _mm_adds_epi16(p[0], v);
@@ -128,37 +110,8 @@ matchfinder_rebase_sse2(mf_pos_t *data, size_t size)
 		p[2] = _mm_adds_epi16(p[2], v);
 		p[3] = _mm_adds_epi16(p[3], v);
 		p += 4;
-	} while (--n);
-	return true;
+		size -= 4 * sizeof(*p);
+	} while (size != 0);
 }
+#define matchfinder_rebase matchfinder_rebase_sse2
 #endif /* __SSE2__ */
-
-#undef arch_matchfinder_init
-static forceinline bool
-arch_matchfinder_init(mf_pos_t *data, size_t size)
-{
-#ifdef __AVX2__
-	if (matchfinder_init_avx2(data, size))
-		return true;
-#endif
-#ifdef __SSE2__
-	if (matchfinder_init_sse2(data, size))
-		return true;
-#endif
-	return false;
-}
-
-#undef arch_matchfinder_rebase
-static forceinline bool
-arch_matchfinder_rebase(mf_pos_t *data, size_t size)
-{
-#ifdef __AVX2__
-	if (matchfinder_rebase_avx2(data, size))
-		return true;
-#endif
-#ifdef __SSE2__
-	if (matchfinder_rebase_sse2(data, size))
-		return true;
-#endif
-	return false;
-}


### PR DESCRIPTION
Remove the ability of matchfinder_init() and matchfinder_rebase() to
fail due to the matchfinder memory size being misaligned.  Instead,
require that the size always be 128-byte aligned -- which is already the
case.  Also, make the matchfinder memory always be 32-byte aligned --
which doesn't really have any downside.