### PR TITLE
Remove Travis CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Build Status](https://travis-ci.org/ebiggers/libdeflate.svg?branch=master)](https://travis-ci.org/ebiggers/libdeflate)
-
 # Overview
 
 libdeflate is a library for fast, whole-buffer DEFLATE-based compression and


### PR DESCRIPTION
No longer applicable, now that we're using GitHub Actions instead.