### PR TITLE
programs/prog_util.h: include sys/types.h

### DIFF
--- a/programs/prog_util.h
+++ b/programs/prog_util.h
@@ -38,6 +38,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifndef _WIN32
+#  include <sys/types.h>
+#endif
 
 #include "../common/common_defs.h"
 


### PR DESCRIPTION
Include `sys/types.h` to avoid the following build failure on uclibc:

```
In file included from programs/gzip.c:28:0:
programs/prog_util.h:159:1: error: unknown type name ‘ssize_t’
 ssize_t xread(struct file_stream *strm, void *buf, size_t count);
 ^
```

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>