### PR TITLE
lib: consistently use include guards

### DIFF
--- a/lib/arm/adler32_impl.h
+++ b/lib/arm/adler32_impl.h
@@ -25,6 +25,9 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#ifndef LIB_ARM_ADLER32_IMPL_H
+#define LIB_ARM_ADLER32_IMPL_H
+
 #include "cpu_features.h"
 
 /* NEON implementation */
@@ -118,3 +121,5 @@ arch_select_adler32_func(void)
 	return NULL;
 }
 #endif /* DISPATCH */
+
+#endif /* LIB_ARM_ADLER32_IMPL_H */

--- a/lib/arm/crc32_impl.h
+++ b/lib/arm/crc32_impl.h
@@ -26,6 +26,9 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#ifndef LIB_ARM_CRC32_IMPL_H
+#define LIB_ARM_CRC32_IMPL_H
+
 #include "cpu_features.h"
 
 /* Implementation using ARM CRC32 instructions */
@@ -240,3 +243,5 @@ arch_select_crc32_func(void)
 	return NULL;
 }
 #endif /* DISPATCH */
+
+#endif /* LIB_ARM_CRC32_IMPL_H */

--- a/lib/arm/matchfinder_impl.h
+++ b/lib/arm/matchfinder_impl.h
@@ -25,6 +25,9 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#ifndef LIB_ARM_MATCHFINDER_IMPL_H
+#define LIB_ARM_MATCHFINDER_IMPL_H
+
 #ifdef __ARM_NEON
 #  include <arm_neon.h>
 static forceinline void
@@ -79,3 +82,5 @@ matchfinder_rebase_neon(mf_pos_t *data, size_t size)
 #define matchfinder_rebase matchfinder_rebase_neon
 
 #endif /* __ARM_NEON */
+
+#endif /* LIB_ARM_MATCHFINDER_IMPL_H */

--- a/lib/bt_matchfinder.h
+++ b/lib/bt_matchfinder.h
@@ -64,6 +64,8 @@
  * ----------------------------------------------------------------------------
  */
 
+#ifndef LIB_BT_MATCHFINDER_H
+#define LIB_BT_MATCHFINDER_H
 
 #include "matchfinder_common.h"
 
@@ -357,3 +359,5 @@ bt_matchfinder_skip_position(struct bt_matchfinder *mf,
 					NULL,
 					false);
 }
+
+#endif /* LIB_BT_MATCHFINDER_H */

--- a/lib/cpu_features_common.h
+++ b/lib/cpu_features_common.h
@@ -25,6 +25,9 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#ifndef LIB_CPU_FEATURES_COMMON_H
+#define LIB_CPU_FEATURES_COMMON_H
+
 #if defined(TEST_SUPPORT__DO_NOT_USE) && !defined(FREESTANDING)
 #  define _GNU_SOURCE 1 /* for strdup() and strtok_r() */
 #  include <stdio.h>
@@ -81,3 +84,5 @@ disable_cpu_features_for_testing(u32 *features,
 {
 }
 #endif /* !TEST_SUPPORT__DO_NOT_USE */
+
+#endif /* LIB_CPU_FEATURES_COMMON_H */

--- a/lib/hc_matchfinder.h
+++ b/lib/hc_matchfinder.h
@@ -106,6 +106,9 @@
  * ----------------------------------------------------------------------------
  */
 
+#ifndef LIB_HC_MATCHFINDER_H
+#define LIB_HC_MATCHFINDER_H
+
 #include "matchfinder_common.h"
 
 #define HC_MATCHFINDER_HASH3_ORDER	15
@@ -405,3 +408,5 @@ hc_matchfinder_skip_positions(struct hc_matchfinder * const restrict mf,
 
 	return in_next;
 }
+
+#endif /* LIB_HC_MATCHFINDER_H */

--- a/lib/x86/adler32_impl.h
+++ b/lib/x86/adler32_impl.h
@@ -25,6 +25,9 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#ifndef LIB_X86_ADLER32_IMPL_H
+#define LIB_X86_ADLER32_IMPL_H
+
 #include "cpu_features.h"
 
 /*
@@ -330,3 +333,5 @@ arch_select_adler32_func(void)
 	return NULL;
 }
 #endif /* DISPATCH */
+
+#endif /* LIB_X86_ADLER32_IMPL_H */

--- a/lib/x86/crc32_impl.h
+++ b/lib/x86/crc32_impl.h
@@ -25,6 +25,9 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#ifndef LIB_X86_CRC32_IMPL_H
+#define LIB_X86_CRC32_IMPL_H
+
 #include "cpu_features.h"
 
 /*
@@ -85,3 +88,5 @@ arch_select_crc32_func(void)
 	return NULL;
 }
 #endif /* DISPATCH */
+
+#endif /* LIB_X86_CRC32_IMPL_H */

--- a/lib/x86/decompress_impl.h
+++ b/lib/x86/decompress_impl.h
@@ -1,3 +1,6 @@
+#ifndef LIB_X86_DECOMPRESS_IMPL_H
+#define LIB_X86_DECOMPRESS_IMPL_H
+
 #include "cpu_features.h"
 
 /* Include the BMI2-optimized version? */
@@ -24,3 +27,5 @@ arch_select_decompress_func(void)
 	return NULL;
 }
 #endif /* DISPATCH */
+
+#endif /* LIB_X86_DECOMPRESS_IMPL_H */

--- a/lib/x86/matchfinder_impl.h
+++ b/lib/x86/matchfinder_impl.h
@@ -25,6 +25,9 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#ifndef LIB_X86_MATCHFINDER_IMPL_H
+#define LIB_X86_MATCHFINDER_IMPL_H
+
 #ifdef __AVX2__
 #  include <immintrin.h>
 static forceinline void
@@ -115,3 +118,5 @@ matchfinder_rebase_sse2(mf_pos_t *data, size_t size)
 }
 #define matchfinder_rebase matchfinder_rebase_sse2
 #endif /* __SSE2__ */
+
+#endif /* LIB_X86_MATCHFINDER_IMPL_H */


### PR DESCRIPTION
A lot of the internal library headers don't have include guards because
they aren't needed.  It might look like a bug, though, and it doesn't
hurt to add them.  So do this.

Update https://github.com/ebiggers/libdeflate/issues/117