### PR TITLE
fix ICC compilation

### DIFF
--- a/common/compiler_gcc.h
+++ b/common/compiler_gcc.h
@@ -147,7 +147,8 @@
  * needed.
  */
 #if (GCC_PREREQ(4, 0) && !GCC_PREREQ(5, 1)) || \
-    (defined(__clang__) && !CLANG_PREREQ(3, 9, 8020000))
+    (defined(__clang__) && !CLANG_PREREQ(3, 9, 8020000)) || \
+    defined(__INTEL_COMPILER)
 typedef unsigned long long  __v2du __attribute__((__vector_size__(16)));
 typedef unsigned int        __v4su __attribute__((__vector_size__(16)));
 typedef unsigned short      __v8hu __attribute__((__vector_size__(16)));
@@ -156,6 +157,12 @@ typedef unsigned long long  __v4du __attribute__((__vector_size__(32)));
 typedef unsigned int        __v8su __attribute__((__vector_size__(32)));
 typedef unsigned short     __v16hu __attribute__((__vector_size__(32)));
 typedef unsigned char      __v32qu __attribute__((__vector_size__(32)));
+#endif
+
+#ifdef __INTEL_COMPILER
+typedef int   __v16si __attribute__((__vector_size__(64)));
+typedef short __v32hi __attribute__((__vector_size__(64)));
+typedef char  __v64qi __attribute__((__vector_size__(64)));
 #endif
 
 /* Newer gcc supports __BYTE_ORDER__.  Older gcc doesn't. */

--- a/lib/x86/crc32_pclmul_template.h
+++ b/lib/x86/crc32_pclmul_template.h
@@ -25,7 +25,7 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#include <wmmintrin.h>
+#include <immintrin.h>
 
 /*
  * CRC-32 folding with PCLMULQDQ.


### PR DESCRIPTION
now icc oneapi is freeware, so we can test it.

related to #21 

- on ICC, __v2di is defined in immintrin.h

```
In file included from lib/x86/crc32_impl.h(52),
                 from lib/crc32.c(186):
lib/x86/crc32_pclmul_template.h(107): error: identifier "__v2di" is undefined
  	const __v2di multipliers_4 = (__v2di){ 0x8F352D95, 0x1D9513D7 };
```

- __v64qi etc are not available on ICC

```
In file included from lib/adler32.c(65):
lib/x86/adler32_impl.h(114): error: identifier "__v64qi" is undefined
  	const __v64qi multipliers = (__v64qi){
```

tested with `icc (ICC) 2021.2.0 20210228`