### PR TITLE
Generate a pkg-config support file #140

### DIFF
--- a/libdeflate.pc.in
+++ b/libdeflate.pc.in
@@ -1,0 +1,10 @@
+prefix=@PREFIX@
+exec_prefix=${prefix}
+includedir=@INCDIR@
+libdir=@LIBDIR@
+
+Name: libdeflate
+Description: Fast implementation of DEFLATE, zlib, and gzip
+Version: @VERSION@
+Libs: -L${libdir} -ldeflate
+Cflags: -I${includedir}


### PR DESCRIPTION
Doing this from within Make requires either a bunch of sed plus a template file, or use of GNU Make's
file functionality. I opted for the latter. Set the necessary Cflags and Libs (CFLAGS and LFLAGS) based
off compile-time definitions. Depend on the Makefile to pick up version changes.

As noted, we probably want to write the version in `libdeflate.h` based off the VERSION property introduced by this change.