### PR TITLE
Improve handling of input overreads

### DIFF
--- a/lib/decompress_template.h
+++ b/lib/decompress_template.h
@@ -43,7 +43,7 @@ FUNCNAME(struct libdeflate_decompressor * restrict d,
 	const u8 * const in_end = in_next + in_nbytes;
 	bitbuf_t bitbuf = 0;
 	unsigned bitsleft = 0;
-	size_t overrun_count = 0;
+	size_t overread_count = 0;
 	unsigned i;
 	unsigned is_final_block;
 	unsigned block_type;

--- a/lib/deflate_decompress.c
+++ b/lib/deflate_decompress.c
@@ -222,7 +222,7 @@ do {								\
 	if (likely(in_next != in_end))				\
 		bitbuf |= (bitbuf_t)*in_next++ << bitsleft;	\
 	else							\
-		overrun_count++;				\
+		overread_count++;				\
 	bitsleft += 8;						\
 } while (bitsleft <= BITBUF_NBITS - 8)
 
@@ -307,9 +307,9 @@ if (!HAVE_BITS(n)) {						\
  */
 #define ALIGN_INPUT()							\
 do {									\
-	SAFETY_CHECK(overrun_count <= (bitsleft >> 3));			\
-	in_next -= (bitsleft >> 3) - overrun_count;			\
-	overrun_count = 0;						\
+	SAFETY_CHECK(overread_count <= (bitsleft >> 3));			\
+	in_next -= (bitsleft >> 3) - overread_count;			\
+	overread_count = 0;						\
 	bitbuf = 0;							\
 	bitsleft = 0;							\
 } while(0)


### PR DESCRIPTION
* deflate_decompress: error out if overread count gets too large
* deflate_decompress: rename overrun_count to overread_count
* gunzip: limit uncompressed buffer size to 1032x compressed size