### PR TITLE
fix crc32 build on arm

### DIFF
--- a/common/compiler_gcc.h
+++ b/common/compiler_gcc.h
@@ -128,9 +128,9 @@
       * they work as expected.  (Well, not quite.  There's still a bug, but we
       * have to work around it later when including arm_acle.h.)
       */
-#    if GCC_PREREQ(10, 1) || \
+#    if ((GCC_PREREQ(10, 1) || \
         (GCC_PREREQ(9, 3) && !GCC_PREREQ(10, 0)) || \
-        (GCC_PREREQ(8, 4) && !GCC_PREREQ(9, 0)) || \
+        (GCC_PREREQ(8, 4) && !GCC_PREREQ(9, 0))) && defined(__aarch64__)) || \
         (defined(__clang__) && __has_builtin(__builtin_arm_crc32b))
 #      define COMPILER_SUPPORTS_CRC32_TARGET_INTRINSICS 1
 #    endif


### PR DESCRIPTION
Fixes build error

/tmp/ccAwbDTP.s: Assembler messages:
/tmp/ccAwbDTP.s:140: Error: selected processor does not support `crc32b r0,r0,r3' in ARM mode
/tmp/ccAwbDTP.s:146: Error: selected processor does not support `crc32w r3,r0,r3' in ARM mode
/tmp/ccAwbDTP.s:148: Error: selected processor does not support `crc32w r3,r3,r4' in ARM mode
/tmp/ccAwbDTP.s:150: Error: selected processor does not support `crc32w r3,r3,r4' in ARM mode
/tmp/ccAwbDTP.s:152: Error: selected processor does not support `crc32w r3,r3,r0' in ARM mode
/tmp/ccAwbDTP.s:154: Error: selected processor does not support `crc32w r3,r3,r4' in ARM mode
/tmp/ccAwbDTP.s:156: Error: selected processor does not support `crc32w r3,r3,r0' in ARM mode
/tmp/ccAwbDTP.s:158: Error: selected processor does not support `crc32w r3,r3,r4' in ARM mode
/tmp/ccAwbDTP.s:159: Error: selected processor does not support `crc32w r0,r3,r0' in ARM mode
/tmp/ccAwbDTP.s:165: Error: selected processor does not support `crc32w lr,r0,lr' in ARM mode
/tmp/ccAwbDTP.s:166: Error: selected processor does not support `crc32w r0,lr,r4' in ARM mode
/tmp/ccAwbDTP.s:170: Error: selected processor does not support `crc32b r0,r0,r3' in ARM mode
/tmp/ccAwbDTP.s:177: Error: selected processor does not support `crc32b r0,r0,r3' in ARM mode