### PR TITLE
gzip/gunzip improvements

### DIFF
--- a/programs/prog_util.c
+++ b/programs/prog_util.c
@@ -56,6 +56,9 @@
 /* The invocation name of the program (filename component only) */
 const tchar *prog_invocation_name;
 
+/* Whether to suppress warning messages or not */
+bool suppress_warnings;
+
 static void
 do_msg(const char *format, bool with_errno, va_list va)
 {
@@ -91,6 +94,20 @@ msg_errno(const char *format, ...)
 	va_start(va, format);
 	do_msg(format, true, va);
 	va_end(va);
+}
+
+
+/* Same as msg(), but do nothing if 'suppress_warnings' has been set. */
+void
+warn(const char *format, ...)
+{
+	if (!suppress_warnings) {
+		va_list va;
+
+		va_start(va, format);
+		do_msg(format, false, va);
+		va_end(va);
+	}
 }
 
 /* malloc() wrapper */
@@ -226,8 +243,8 @@ retry:
 		}
 		if (!overwrite) {
 			if (!isatty(STDERR_FILENO) || !isatty(STDIN_FILENO)) {
-				msg("%"TS" already exists; use -f to overwrite",
-				    strm->name);
+				warn("%"TS" already exists; use -f to overwrite",
+				     strm->name);
 				ret = -2; /* warning only */
 				goto err;
 			}

--- a/programs/prog_util.h
+++ b/programs/prog_util.h
@@ -137,9 +137,11 @@ int wmain(int argc, wchar_t **argv);
 #endif /* !_WIN32 */
 
 extern const tchar *prog_invocation_name;
+extern bool suppress_warnings;
 
 void _printf(1, 2) msg(const char *fmt, ...);
 void _printf(1, 2) msg_errno(const char *fmt, ...);
+void _printf(1, 2) warn(const char *fmt, ...);
 
 void *xmalloc(size_t size);
 

--- a/scripts/gzip_tests.sh
+++ b/scripts/gzip_tests.sh
@@ -494,6 +494,12 @@ for contents in "${bad_files[@]}"; do
 done
 
 
+begin_test '-q (quiet) option works'
+mkdir dir
+gunzip -q dir &> output || true
+[ ! -s output ]
+
+
 begin_test 'Version information'
 gzip -V | grep -q Copyright
 gunzip -V | grep -q Copyright

--- a/scripts/gzip_tests.sh
+++ b/scripts/gzip_tests.sh
@@ -225,6 +225,16 @@ gzip -f file.gz
 cmp file.gz.gz c.gz
 
 
+begin_test 'gunzip -f -c passes through non-gzip data'
+echo hello > file
+cp file orig
+gunzip -f -c file > foo
+cmp file foo
+gzip file
+gunzip -f -c file.gz > foo
+cmp foo orig
+
+
 begin_test 'Decompressing unsuffixed file only works with -c'
 gzip file && mv file.gz file
 assert_skipped gunzip file

--- a/scripts/gzip_tests.sh
+++ b/scripts/gzip_tests.sh
@@ -34,6 +34,7 @@ begin_test() {
 	CURRENT_TEST="$1"
 	rm -rf -- "${TMPDIR:?}"/*
 	cp "$TESTDATA" file
+	chmod +w file
 }
 
 gzip() {


### PR DESCRIPTION
* gzip, gunzip: support -q option
* gunzip: make -f and -c together pass through non-gzip data
* gzip_tests: ensure the test file is writable
