### PR TITLE
Building libdeflate on macOS with Apple Silicon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,16 @@
 /test_*
 tags
 cscope*
+
+# Backup files
+*~
+
+# Visual Studio
+.vscode
+*.code-workspace
+
+# macOS
+.DS_Store
+*.swp
+*.lock
+

--- a/Makefile
+++ b/Makefile
@@ -197,8 +197,12 @@ STATIC_LIB := libdeflate$(STATIC_LIB_SUFFIX)
 LIB_CFLAGS += $(CFLAGS) -fvisibility=hidden
 
 # Compiling for macOS on Apple Silicon ?
-ifneq ($(findstring arm64,$(TARGET_MACHINE)),) && ifneq ($(findstring -darwin,$(TARGET_MACHINE)),)
-	LIB_CFLAGS += -D_DARWIN_C_SOURCE
+ifneq ($(findstring arm64,$(TARGET_MACHINE)),)
+	ifneq ($(findstring -darwin,$(TARGET_MACHINE)),)
+		LIB_CFLAGS += -D_DARWIN_C_SOURCE
+	else
+		LIB_CFLAGS += -D_ANSI_SOURCE
+	endif
 else
 	LIB_CFLAGS += -D_ANSI_SOURCE
 endif

--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,14 @@ DEFAULT_TARGETS :=
 
 STATIC_LIB := libdeflate$(STATIC_LIB_SUFFIX)
 
-LIB_CFLAGS += $(CFLAGS) -fvisibility=hidden -D_ANSI_SOURCE
+LIB_CFLAGS += $(CFLAGS) -fvisibility=hidden
+
+# Compiling for macOS on Apple Silicon ?
+ifneq ($(findstring arm64,$(TARGET_MACHINE)),) && ifneq ($(findstring -darwin,$(TARGET_MACHINE)),)
+	LIB_CFLAGS += -D_DARWIN_C_SOURCE
+else
+	LIB_CFLAGS += -D_ANSI_SOURCE
+endif
 
 LIB_HEADERS := $(wildcard lib/*.h) $(wildcard lib/*/*.h)
 


### PR DESCRIPTION
When compiling libdeflate on macOS with an Apple Silicon cpu, you get the error:

`
In file included from lib/arm/cpu_features.c:130: In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/sysctl.h:83: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/ucred.h:104:20: error: use of undeclared identifier 'NGROUPS_MAX' gid_t cr_groups[NGROUPS]; /* advisory group list */ ^ /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/param.h:100:25: note: expanded from macro 'NGROUPS' #define NGROUPS NGROUPS_MAX /* max number groups */
`

This patch fixes the above error by defining -D_DARWIN_C_SOURCE when building libdeflate on Apple Silicon cpu
