### PR TITLE
lib/arm/cpu_features: fix Apple build

### DIFF
--- a/lib/arm/cpu_features.c
+++ b/lib/arm/cpu_features.c
@@ -30,6 +30,11 @@
  * features.  But an OS-specific way can be used when available.
  */
 
+#ifdef __APPLE__
+#undef _ANSI_SOURCE
+#define _DARWIN_C_SOURCE /* for sysctlbyname() */
+#endif
+
 #include "../cpu_features_common.h" /* must be included first */
 #include "cpu_features.h"
 


### PR DESCRIPTION
Fix the following build error:

In file included from lib/arm/cpu_features.c:130:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/sysctl.h:83:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/ucred.h:104:20: error: use of undeclared identifier 'NGROUPS_MAX'
        gid_t   cr_groups[NGROUPS];     /* advisory group list */