### PR TITLE
Don't use stdcall on 32-bit Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,11 +99,6 @@ ifneq ($(findstring -mingw,$(TARGET_MACHINE))$(findstring -windows-gnu,$(TARGET_
     SHARED_LIB_CFLAGS  :=
     SHARED_LIB_LDFLAGS := -Wl,--out-implib,libdeflate.lib \
                           -Wl,--output-def,libdeflate.def
-    # Only if not LLVM
-    ifeq ($(findstring -windows-gnu,$(TARGET_MACHINE)),)
-        SHARED_LIB_LDFLAGS += -Wl,--add-stdcall-alias
-    endif
-
     PROG_SUFFIX        := .exe
     PROG_CFLAGS        := -static -municode
     HARD_LINKS         :=

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # libdeflate release notes
 
+## [git master branch]
+
+* On Windows, libdeflate has changed back to always using the default calling
+  convention ("cdecl"), instead of "stdcall".
+
 ## Version 1.12
 
 This release focuses on improving the performance of the CRC-32 and Adler-32

--- a/README.md
+++ b/README.md
@@ -183,10 +183,7 @@ guessing.  However, libdeflate's decompression routines do optionally provide
 the actual number of output bytes in case you need it.
 
 Windows developers: note that the calling convention of libdeflate.dll is
-"stdcall" -- the same as the Win32 API.  If you call into libdeflate.dll using a
-non-C/C++ language, or dynamically using LoadLibrary(), make sure to use the
-stdcall convention.  Using the wrong convention may crash your application.
-(Note: older versions of libdeflate used the "cdecl" convention instead.)
+"cdecl".  (libdeflate v1.4 through v1.12 used "stdcall" instead.)
 
 # Bindings for other programming languages
 

--- a/libdeflate.h
+++ b/libdeflate.h
@@ -18,7 +18,7 @@ extern "C" {
 
 /*
  * On Windows, if you want to link to the DLL version of libdeflate, then
- * #define LIBDEFLATE_DLL.  Note that the calling convention is "stdcall".
+ * #define LIBDEFLATE_DLL.  Note that the calling convention is "cdecl".
  */
 #ifdef LIBDEFLATE_DLL
 #  ifdef BUILDING_LIBDEFLATE
@@ -31,12 +31,6 @@ extern "C" {
 #  define LIBDEFLATEEXPORT
 #endif
 
-#if defined(_WIN32) && !defined(_WIN64) && defined(LIBDEFLATE_DLL)
-#  define LIBDEFLATEAPI_ABI	__stdcall
-#else
-#  define LIBDEFLATEAPI_ABI
-#endif
-
 #if defined(BUILDING_LIBDEFLATE) && defined(__GNUC__) && \
 	defined(_WIN32) && !defined(_WIN64)
     /*
@@ -44,12 +38,10 @@ extern "C" {
      * Realign the stack when entering libdeflate to avoid crashing in SSE/AVX
      * code when called from an MSVC-compiled application.
      */
-#  define LIBDEFLATEAPI_STACKALIGN	__attribute__((force_align_arg_pointer))
+#  define LIBDEFLATEAPI	__attribute__((force_align_arg_pointer))
 #else
-#  define LIBDEFLATEAPI_STACKALIGN
+#  define LIBDEFLATEAPI
 #endif
-
-#define LIBDEFLATEAPI	LIBDEFLATEAPI_ABI LIBDEFLATEAPI_STACKALIGN
 
 /* ========================================================================== */
 /*                             Compression                                    */


### PR DESCRIPTION
Using stdcall in DLL builds but not static library builds (as commit
7e82d450694b did) is problematic because it made it so that
LIBDEFLATE_DLL needs to be defined when linking to libdeflate.dll with
any compiler, rather than just with MSVC as was the case before.

Given that the only reported use case for stdcall is VB6 support, and
VB6 is basically dead, and anyone who *really* wants to still use VB6
could still make a wrapper library to translate between stdcall and
cdecl, let's just always use the default calling convention (cdecl).

Update https://github.com/ebiggers/libdeflate/pull/178