### PR TITLE
libdeflate.pc.in: add CFLAGS for shared and static linking

### DIFF
--- a/libdeflate.pc.in
+++ b/libdeflate.pc.in
@@ -7,4 +7,5 @@ Name: libdeflate
 Description: Fast implementation of DEFLATE, zlib, and gzip
 Version: @VERSION@
 Libs: -L${libdir} -ldeflate
-Cflags: -I${includedir}
+Cflags: -I${includedir} -DLIBDEFLATE_DLL
+Cflags.private: -ULIBDEFLATE_DLL


### PR DESCRIPTION
The shared library is built with `-DLIBDEFLATE_DLL`. That means that the calling convention is set to `__stdcall` on Windows 32-bit.
When linking to that shared library, the header must use the same calling convention. Currently, the user would need to do that manually.
It would be nice if the correct flags were set in the pkg-config file.

This PR adds `-DLIBDEFLATE_DLL` to the `Cflags` in that file. That would select the correct calling convention for shared linking:
```
$ pkg-config --cflags libdeflate
-IC:/msys64/mingw32/include -DLIBDEFLATE_DLL
```

Additionally, it adds `-ULIBDEFLATE_DLL` to the `Cflags.private` in that file. That would result in the following CFLAGS for static linking:
```
$ pkg-config --cflags --static libdeflate
-IC:/msys64/mingw32/include -DLIBDEFLATE_DLL -ULIBDEFLATE_DLL
```
Since the static flags appear after the "normal" flags, the `-U` flag effectively undoes the `-D` flag.

This seems to be working correctly on Windows 32-bit with MinGW. See also https://github.com/msys2/MINGW-packages/pull/11886.

IIUC, those flags are only important on Windows 32-bit. But afaict, they don't hurt on other platforms.

Would that change be acceptable?
