### PR TITLE
run_test.sh log function works on macOS

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -57,8 +57,8 @@ done
 INDENT=0
 
 log() {
-	echo -n "[$(date)] "
-	head -c $(( INDENT * 4 )) /dev/zero | tr '\0' ' '
+	printf "[$(date)] "
+	test $INDENT -gt 0 && head -c $(( INDENT * 4 )) /dev/zero | tr '\0' ' '
 	echo "$@"
 }
 


### PR DESCRIPTION
2 things seem to fail:

```
$ sh scripts/run_tests.sh 
-n [Mon Jun 27 10:22:24 CEST 2022] 
head: illegal byte count -- 0
```

1. The echo -n option is not supported apparently by macOS echo. Instead we can use the printf option which will not print a newline character.
2. macOS head does not like the 0 byte count for the -c option ; so we add a small test to do nothing if INDENT is still zero.

With those changes I can get run_tests.sh going.

```
[Mon Jun 27 10:26:56 CEST 2022] Starting libdeflate tests
[Mon Jun 27 10:26:56 CEST 2022] Running tests
[Mon Jun 27 10:26:56 CEST 2022]     CC=cc CFLAGS="" WRAPPER="" 
[Mon Jun 27 10:26:57 CEST 2022]         Using LIBDEFLATE_DISABLE_CPU_FEATURES=
[Mon Jun 27 10:27:00 CEST 2022]         Using LIBDEFLATE_DISABLE_CPU_FEATURES=sha3
[Mon Jun 27 10:27:00 CEST 2022]         Using LIBDEFLATE_DISABLE_CPU_FEATURES=sha3,crc32
[Mon Jun 27 10:27:01 CEST 2022]         Using LIBDEFLATE_DISABLE_CPU_FEATURES=sha3,crc32,pmull
[Mon Jun 27 10:27:02 CEST 2022]         Using LIBDEFLATE_DISABLE_CPU_FEATURES=sha3,crc32,pmull,neon
[Mon Jun 27 10:27:02 CEST 2022]     CC=cc CFLAGS="" WRAPPER="" FREESTANDING=1
...
```