### PR TITLE
Always use force_align_arg_pointer on i386

### DIFF
--- a/libdeflate.h
+++ b/libdeflate.h
@@ -31,12 +31,13 @@ extern "C" {
 #  define LIBDEFLATEEXPORT
 #endif
 
-#if defined(BUILDING_LIBDEFLATE) && defined(__GNUC__) && \
-	defined(_WIN32) && !defined(_WIN64)
+#if defined(BUILDING_LIBDEFLATE) && defined(__GNUC__) && defined(__i386__)
     /*
-     * On 32-bit Windows, gcc assumes 16-byte stack alignment but MSVC only 4.
-     * Realign the stack when entering libdeflate to avoid crashing in SSE/AVX
-     * code when called from an MSVC-compiled application.
+     * On i386, gcc assumes that the stack is 16-byte aligned at function entry.
+     * However, some compilers (e.g. MSVC) and programming languages (e.g.
+     * Delphi) only guarantee 4-byte alignment when calling functions.  Work
+     * around this ABI incompatibility by realigning the stack pointer when
+     * entering libdeflate.  This prevents crashes in SSE/AVX code.
      */
 #  define LIBDEFLATEAPI	__attribute__((force_align_arg_pointer))
 #else


### PR DESCRIPTION
This hopefully will address the issue that is being worked around by https://github.com/synopse/mORMot2/commit/87e624cbb7049447.  This isn't really a bug in libdeflate, but rather an ABI incompatibility between gcc and other compilers and programming languages on i386; however, we can work around it.