### PR TITLE
Use MinGW naming convention for Windows libraries

### DIFF
--- a/scripts/make-windows-releases.sh
+++ b/scripts/make-windows-releases.sh
@@ -9,8 +9,7 @@ for arch in 'i686' 'x86_64'; do
 	dir=libdeflate-$(git describe --tags | tr -d v)-windows-${arch}-bin
 	rm -rf "$dir" "$dir.zip"
 	mkdir "$dir"
-	cp libdeflate.{dll,lib,def} libdeflatestatic.lib libdeflate.h ./*.exe \
-		"$dir"
+	cp libdeflate.{dll,dll.a,def,a} libdeflate.h ./*.exe "$dir"
 	${arch}-w64-mingw32-strip "$dir/libdeflate.dll" "$dir"/*.exe
 	for file in COPYING NEWS.md README.md; do
 		sed < $file > "$dir/${file}.txt" -e 's/$/\r/g'


### PR DESCRIPTION
For the import and static libraries, use the MinGW naming convention (libdeflate.dll.a and libdeflate.a, respectively) instead of the Visual Studio naming convention (libdeflate.lib and libdeflatestatic.lib, respectively).  The original assumption was that the native Windows convention was better.  However, instead people expect the naming convention to reflect the toolchain with which the files were built.

Also change 'make install' to install the DLL into the bin directory instead of the lib directory, again following the MinGW convention.

Fixes https://github.com/ebiggers/libdeflate/issues/190