### PR TITLE
Avoid lib name collision with MSVC builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,8 +170,13 @@ if(LIBDEFLATE_BUILD_STATIC_LIB)
     # same way with add_subdirectory() as with other ways.
     add_library(libdeflate::libdeflate_static ALIAS libdeflate_static)
 
+    if(WIN32 AND NOT MINGW)
+        set(STATIC_LIB_NAME deflatestatic)
+    else()
+        set(STATIC_LIB_NAME deflate)
+    endif()
     set_target_properties(libdeflate_static PROPERTIES
-                          OUTPUT_NAME deflate
+                          OUTPUT_NAME ${STATIC_LIB_NAME}
                           PUBLIC_HEADER libdeflate.h)
     target_include_directories(libdeflate_static PUBLIC ${LIB_INCLUDE_DIRS})
     target_compile_definitions(libdeflate_static PUBLIC LIBDEFLATE_STATIC)


### PR DESCRIPTION
When WIN32 && !MINGW, call the static library libdeflatestatic.lib so that it doesn't collide with the import library libdeflate.lib.

Fixes https://github.com/ebiggers/libdeflate/issues/236