### PR TITLE
Visual Studio build updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,13 +105,22 @@ jobs:
     - run: cmake --build build --verbose
     - run: ctest --test-dir build
 
-  windows-msvc-build:
-    name: Build (Windows, Visual Studio)
+  windows-visualstudio-msvc-build:
+    name: Build (Windows, Visual Studio + MSVC)
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
     - uses: microsoft/setup-msbuild@v1.1
     - run: cmake -B build -G "Visual Studio 17 2022"
+    - run: cmake --build build --verbose
+
+  windows-visualstudio-clang-build:
+    name: Build (Windows, Visual Studio + Clang)
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: microsoft/setup-msbuild@v1.1
+    - run: cmake -B build -G "Visual Studio 17 2022" -T ClangCL
     - run: cmake --build build --verbose
 
   run-clang-static-analyzer:

--- a/common_defs.h
+++ b/common_defs.h
@@ -33,6 +33,11 @@
 #include <stdint.h>
 #ifdef _MSC_VER
 #  include <stdlib.h>	/* for _byteswap_*() */
+   /* Disable some annoying warnings that MSVC enables by default. */
+#  pragma warning(disable : 4018) /* signed/unsigned mismatch */
+#  pragma warning(disable : 4146) /* unary minus on unsigned type */
+#  pragma warning(disable : 4244) /* possible loss of data */
+#  pragma warning(disable : 4267) /* possible loss of precision */
 #endif
 #ifndef FREESTANDING
 #  include <string.h>	/* for memcpy() */

--- a/lib/x86/cpu_features.h
+++ b/lib/x86/cpu_features.h
@@ -39,6 +39,13 @@
 #  define HAVE_DYNAMIC_X86_CPU_FEATURES	1
 #endif
 
+#ifdef __GNUC__
+#  define HAVE_INTRIN	1
+#else
+ /* intrinsics not compatible (e.g. MSVC, or clang in MSVC mode) */
+#  define HAVE_INTRIN	0
+#endif
+
 #define X86_CPU_FEATURE_SSE2		0x00000001
 #define X86_CPU_FEATURE_PCLMUL		0x00000002
 #define X86_CPU_FEATURE_AVX		0x00000004
@@ -109,7 +116,8 @@ typedef char  __v64qi __attribute__((__vector_size__(64)));
 #endif
 #define HAVE_SSE2_TARGET	HAVE_DYNAMIC_X86_CPU_FEATURES
 #define HAVE_SSE2_INTRIN \
-	(HAVE_SSE2_NATIVE || (HAVE_SSE2_TARGET && HAVE_TARGET_INTRINSICS))
+	(HAVE_INTRIN &&	\
+	 (HAVE_SSE2_NATIVE || (HAVE_SSE2_TARGET && HAVE_TARGET_INTRINSICS)))
 
 /* PCLMUL */
 #ifdef __PCLMUL__
@@ -121,7 +129,8 @@ typedef char  __v64qi __attribute__((__vector_size__(64)));
 	(HAVE_DYNAMIC_X86_CPU_FEATURES && \
 	 (GCC_PREREQ(4, 4) || __has_builtin(__builtin_ia32_pclmulqdq128)))
 #define HAVE_PCLMUL_INTRIN \
-	(HAVE_PCLMUL_NATIVE || (HAVE_PCLMUL_TARGET && HAVE_TARGET_INTRINSICS))
+	(HAVE_INTRIN && \
+	 (HAVE_PCLMUL_NATIVE || (HAVE_PCLMUL_TARGET && HAVE_TARGET_INTRINSICS)))
 
 /* AVX */
 #ifdef __AVX__
@@ -133,7 +142,8 @@ typedef char  __v64qi __attribute__((__vector_size__(64)));
 	(HAVE_DYNAMIC_X86_CPU_FEATURES && \
 	 (GCC_PREREQ(4, 6) || __has_builtin(__builtin_ia32_maxps256)))
 #define HAVE_AVX_INTRIN \
-	(HAVE_AVX_NATIVE || (HAVE_AVX_TARGET && HAVE_TARGET_INTRINSICS))
+	(HAVE_INTRIN && \
+	 (HAVE_AVX_NATIVE || (HAVE_AVX_TARGET && HAVE_TARGET_INTRINSICS)))
 
 /* AVX2 */
 #ifdef __AVX2__
@@ -145,7 +155,8 @@ typedef char  __v64qi __attribute__((__vector_size__(64)));
 	(HAVE_DYNAMIC_X86_CPU_FEATURES && \
 	 (GCC_PREREQ(4, 7) || __has_builtin(__builtin_ia32_psadbw256)))
 #define HAVE_AVX2_INTRIN \
-	(HAVE_AVX2_NATIVE || (HAVE_AVX2_TARGET && HAVE_TARGET_INTRINSICS))
+	(HAVE_INTRIN && \
+	 (HAVE_AVX2_NATIVE || (HAVE_AVX2_TARGET && HAVE_TARGET_INTRINSICS)))
 
 /* BMI2 */
 #ifdef __BMI2__
@@ -157,7 +168,8 @@ typedef char  __v64qi __attribute__((__vector_size__(64)));
 	(HAVE_DYNAMIC_X86_CPU_FEATURES && \
 	 (GCC_PREREQ(4, 7) || __has_builtin(__builtin_ia32_pdep_di)))
 #define HAVE_BMI2_INTRIN \
-	(HAVE_BMI2_NATIVE || (HAVE_BMI2_TARGET && HAVE_TARGET_INTRINSICS))
+	(HAVE_INTRIN && \
+	 (HAVE_BMI2_NATIVE || (HAVE_BMI2_TARGET && HAVE_TARGET_INTRINSICS)))
 
 #endif /* __i386__ || __x86_64__ */
 

--- a/programs/prog_util.h
+++ b/programs/prog_util.h
@@ -28,6 +28,21 @@
 #ifndef PROGRAMS_PROG_UTIL_H
 #define PROGRAMS_PROG_UTIL_H
 
+/*
+ * To keep the code similar on all platforms, sometimes we intentionally use the
+ * "deprecated" non-underscore-prefixed variants of functions in msvcrt.
+ */
+#if defined(_WIN32) && !defined(_CRT_NONSTDC_NO_DEPRECATE)
+#  define _CRT_NONSTDC_NO_DEPRECATE 1
+#endif
+/*
+ * Similarly, to match other platforms we intentionally use the "non-secure"
+ * variants, which aren't actually any less secure when used properly.
+ */
+#if defined(_WIN32) && !defined(_CRT_SECURE_NO_WARNINGS)
+#  define _CRT_SECURE_NO_WARNINGS 1
+#endif
+
 #ifdef HAVE_CONFIG_H
 #  include "config.h"
 #endif

--- a/programs/prog_util.h
+++ b/programs/prog_util.h
@@ -60,7 +60,7 @@
 
 #include "../common_defs.h"
 
-#ifdef __GNUC__
+#if defined(__GNUC__) || __has_attribute(format)
 # define _printf(str_idx, args_idx)	\
 		__attribute__((format(printf, str_idx, args_idx)))
 #else
@@ -75,6 +75,7 @@
  * get full Unicode support on Windows...
  */
 
+#include <io.h>
 #include <wchar.h>
 int wmain(int argc, wchar_t **argv);
 #  define	tmain		wmain

--- a/programs/test_util.h
+++ b/programs/test_util.h
@@ -32,7 +32,7 @@
 
 #include <zlib.h> /* for comparison purposes */
 
-#ifdef __GNUC__
+#if defined(__GNUC__) || __has_attribute(noreturn)
 # define _noreturn __attribute__((noreturn))
 #else
 # define _noreturn


### PR DESCRIPTION
* common_defs: disable annoying MSVC default warnings
* prog_util: disable annoying msvcrt warning
* Support building with Visual Studio + Clang