### PR TITLE
MSVC support for most of lib/x86/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,22 +105,17 @@ jobs:
     - run: cmake --build build --verbose
     - run: ctest --test-dir build
 
-  windows-visualstudio-msvc-build:
-    name: Build (Windows, Visual Studio + MSVC)
+  windows-visualstudio-build:
+    name: Build (Windows, Visual Studio ${{matrix.toolset}}, ${{matrix.platform}})
+    strategy:
+      matrix:
+        platform: [x64, Win32]
+        toolset: [v143, ClangCL]
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
     - uses: microsoft/setup-msbuild@v1.1
-    - run: cmake -B build -G "Visual Studio 17 2022"
-    - run: cmake --build build --verbose
-
-  windows-visualstudio-clang-build:
-    name: Build (Windows, Visual Studio + Clang)
-    runs-on: windows-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: microsoft/setup-msbuild@v1.1
-    - run: cmake -B build -G "Visual Studio 17 2022" -T ClangCL
+    - run: cmake -B build -G "Visual Studio 17 2022" -T ${{matrix.toolset}} -A ${{matrix.platform}}
     - run: cmake --build build --verbose
 
   run-clang-static-analyzer:

--- a/lib/bt_matchfinder.h
+++ b/lib/bt_matchfinder.h
@@ -85,7 +85,7 @@ struct lz_match {
 	u16 offset;
 };
 
-struct bt_matchfinder {
+struct MATCHFINDER_ALIGNED bt_matchfinder {
 
 	/* The hash table for finding length 3 matches  */
 	mf_pos_t hash3_tab[1UL << BT_MATCHFINDER_HASH3_ORDER][BT_MATCHFINDER_HASH3_WAYS];
@@ -98,8 +98,7 @@ struct bt_matchfinder {
 	 * children of the node for the sequence with position 'pos' are
 	 * 'child_tab[pos * 2]' and 'child_tab[pos * 2 + 1]', respectively.  */
 	mf_pos_t child_tab[2UL * MATCHFINDER_WINDOW_SIZE];
-
-} MATCHFINDER_ALIGNED;
+};
 
 /* Prepare the matchfinder for a new input buffer.  */
 static forceinline void

--- a/lib/hc_matchfinder.h
+++ b/lib/hc_matchfinder.h
@@ -116,7 +116,7 @@
 	(((1UL << HC_MATCHFINDER_HASH3_ORDER) +		\
 	  (1UL << HC_MATCHFINDER_HASH4_ORDER)) * sizeof(mf_pos_t))
 
-struct hc_matchfinder {
+struct MATCHFINDER_ALIGNED hc_matchfinder  {
 
 	/* The hash table for finding length 3 matches  */
 	mf_pos_t hash3_tab[1UL << HC_MATCHFINDER_HASH3_ORDER];
@@ -128,8 +128,7 @@ struct hc_matchfinder {
 	/* The "next node" references for the linked lists.  The "next node" of
 	 * the node for the sequence with position 'pos' is 'next_tab[pos]'.  */
 	mf_pos_t next_tab[MATCHFINDER_WINDOW_SIZE];
-
-} MATCHFINDER_ALIGNED;
+};
 
 /* Prepare the matchfinder for a new input buffer.  */
 static forceinline void

--- a/lib/ht_matchfinder.h
+++ b/lib/ht_matchfinder.h
@@ -54,10 +54,10 @@
 /* Minimum value of max_len for ht_matchfinder_longest_match() */
 #define HT_MATCHFINDER_REQUIRED_NBYTES	5
 
-struct ht_matchfinder {
+struct MATCHFINDER_ALIGNED ht_matchfinder {
 	mf_pos_t hash_tab[1UL << HT_MATCHFINDER_HASH_ORDER]
 			 [HT_MATCHFINDER_BUCKET_SIZE];
-} MATCHFINDER_ALIGNED;
+};
 
 static forceinline void
 ht_matchfinder_init(struct ht_matchfinder *mf)

--- a/lib/x86/cpu_features.c
+++ b/lib/x86/cpu_features.c
@@ -42,17 +42,30 @@
 static inline void
 cpuid(u32 leaf, u32 subleaf, u32 *a, u32 *b, u32 *c, u32 *d)
 {
+#ifdef _MSC_VER
+	int result[4];
+
+	__cpuidex(result, leaf, subleaf);
+	*a = result[0];
+	*b = result[1];
+	*c = result[2];
+	*d = result[3];
+#else
 	__asm__(".ifnc %%ebx, %1; mov  %%ebx, %1; .endif\n"
 		"cpuid                                  \n"
 		".ifnc %%ebx, %1; xchg %%ebx, %1; .endif\n"
 		: "=a" (*a), EBX_CONSTRAINT (*b), "=c" (*c), "=d" (*d)
 		: "a" (leaf), "c" (subleaf));
+#endif
 }
 
 /* Read an extended control register.  */
 static inline u64
 read_xcr(u32 index)
 {
+#ifdef _MSC_VER
+	return _xgetbv(index);
+#else
 	u32 edx, eax;
 
 	/* Execute the "xgetbv" instruction.  Old versions of binutils do not
@@ -60,6 +73,7 @@ read_xcr(u32 index)
 	__asm__ (".byte 0x0f, 0x01, 0xd0" : "=d" (edx), "=a" (eax) : "c" (index));
 
 	return ((u64)edx << 32) | eax;
+#endif
 }
 
 #undef BIT

--- a/lib/x86/cpu_features.h
+++ b/lib/x86/cpu_features.h
@@ -80,25 +80,6 @@ static inline u32 get_x86_cpu_features(void) { return 0; }
 #  define HAVE_TARGET_INTRINSICS	0
 #endif
 
-/*
- * Before gcc 5.1 and clang 3.9, emmintrin.h only defined vectors of signed
- * integers (e.g. __v4si), not vectors of unsigned integers (e.g. __v4su).  We
- * need the unsigned ones to avoid signed integer overflow, which is undefined
- * behavior.  Add the missing definitions for the unsigned ones if needed.
- */
-#if (GCC_PREREQ(4, 0) && !GCC_PREREQ(5, 1)) || \
-	(defined(__clang__) && !CLANG_PREREQ(3, 9, 8020000)) || \
-	defined(__INTEL_COMPILER)
-typedef unsigned long long  __v2du __attribute__((__vector_size__(16)));
-typedef unsigned int        __v4su __attribute__((__vector_size__(16)));
-typedef unsigned short      __v8hu __attribute__((__vector_size__(16)));
-typedef unsigned char      __v16qu __attribute__((__vector_size__(16)));
-typedef unsigned long long  __v4du __attribute__((__vector_size__(32)));
-typedef unsigned int        __v8su __attribute__((__vector_size__(32)));
-typedef unsigned short     __v16hu __attribute__((__vector_size__(32)));
-typedef unsigned char      __v32qu __attribute__((__vector_size__(32)));
-#endif
-
 /* SSE2 */
 #if defined(__SSE2__) || \
 	(defined(_MSC_VER) && \

--- a/lib/x86/cpu_features.h
+++ b/lib/x86/cpu_features.h
@@ -118,17 +118,19 @@ typedef unsigned char      __v32qu __attribute__((__vector_size__(32)));
 #define HAVE_SSE2_INTRIN	(HAVE_SSE2_NATIVE || HAVE_TARGET_INTRINSICS)
 
 /* PCLMUL */
-#ifdef __PCLMUL__
+#if defined(__PCLMUL__) || (defined(_MSC_VER) && defined(__AVX2__))
 #  define HAVE_PCLMUL_NATIVE	1
 #else
 #  define HAVE_PCLMUL_NATIVE	0
 #endif
-#define HAVE_PCLMUL_TARGET \
-	(HAVE_DYNAMIC_X86_CPU_FEATURES && \
-	 (GCC_PREREQ(4, 4) || __has_builtin(__builtin_ia32_pclmulqdq128)))
-#define HAVE_PCLMUL_INTRIN \
-	(HAVE_INTRIN && \
-	 (HAVE_PCLMUL_NATIVE || (HAVE_PCLMUL_TARGET && HAVE_TARGET_INTRINSICS)))
+#if HAVE_PCLMUL_NATIVE || (HAVE_TARGET_INTRINSICS && \
+			   (GCC_PREREQ(4, 4) || \
+			    __has_builtin(__builtin_ia32_pclmulqdq128) || \
+			    defined(_MSC_VER)))
+#  define HAVE_PCLMUL_INTRIN	1
+#else
+#  define HAVE_PCLMUL_INTRIN	0
+#endif
 
 /* AVX */
 #ifdef __AVX__
@@ -136,12 +138,14 @@ typedef unsigned char      __v32qu __attribute__((__vector_size__(32)));
 #else
 #  define HAVE_AVX_NATIVE	0
 #endif
-#define HAVE_AVX_TARGET \
-	(HAVE_DYNAMIC_X86_CPU_FEATURES && \
-	 (GCC_PREREQ(4, 6) || __has_builtin(__builtin_ia32_maxps256)))
-#define HAVE_AVX_INTRIN \
-	(HAVE_INTRIN && \
-	 (HAVE_AVX_NATIVE || (HAVE_AVX_TARGET && HAVE_TARGET_INTRINSICS)))
+#if HAVE_AVX_NATIVE || (HAVE_TARGET_INTRINSICS && \
+			(GCC_PREREQ(4, 6) || \
+			 __has_builtin(__builtin_ia32_maxps256) || \
+			 defined(_MSC_VER)))
+#  define HAVE_AVX_INTRIN	1
+#else
+#  define HAVE_AVX_INTRIN	0
+#endif
 
 /* AVX2 */
 #ifdef __AVX2__

--- a/lib/x86/cpu_features.h
+++ b/lib/x86/cpu_features.h
@@ -107,15 +107,15 @@ typedef unsigned char      __v32qu __attribute__((__vector_size__(32)));
 #endif
 
 /* SSE2 */
-#ifdef __SSE2__
+#if defined(__SSE2__) || \
+	(defined(_MSC_VER) && \
+	 (defined(ARCH_X86_64) || \
+	  (defined(ARCH_X86_32) && defined(_M_IX86_FP) && _M_IX86_FP >= 2)))
 #  define HAVE_SSE2_NATIVE	1
 #else
 #  define HAVE_SSE2_NATIVE	0
 #endif
-#define HAVE_SSE2_TARGET	HAVE_DYNAMIC_X86_CPU_FEATURES
-#define HAVE_SSE2_INTRIN \
-	(HAVE_INTRIN &&	\
-	 (HAVE_SSE2_NATIVE || (HAVE_SSE2_TARGET && HAVE_TARGET_INTRINSICS)))
+#define HAVE_SSE2_INTRIN	(HAVE_SSE2_NATIVE || HAVE_TARGET_INTRINSICS)
 
 /* PCLMUL */
 #ifdef __PCLMUL__

--- a/lib/x86/cpu_features.h
+++ b/lib/x86/cpu_features.h
@@ -34,7 +34,7 @@
 
 #if defined(ARCH_X86_32) || defined(ARCH_X86_64)
 
-#if COMPILER_SUPPORTS_TARGET_FUNCTION_ATTRIBUTE
+#if COMPILER_SUPPORTS_TARGET_FUNCTION_ATTRIBUTE || defined(_MSC_VER)
 #  undef HAVE_DYNAMIC_X86_CPU_FEATURES
 #  define HAVE_DYNAMIC_X86_CPU_FEATURES	1
 #endif
@@ -80,9 +80,12 @@ static inline u32 get_x86_cpu_features(void) { return 0; }
  * functions.  Unfortunately clang has no feature test macro for this, so we
  * have to check its version.
  */
-#define HAVE_TARGET_INTRINSICS \
-	(HAVE_DYNAMIC_X86_CPU_FEATURES && \
-	 (GCC_PREREQ(4, 9) || CLANG_PREREQ(3, 8, 7030000)))
+#if HAVE_DYNAMIC_X86_CPU_FEATURES && \
+	(GCC_PREREQ(4, 9) || CLANG_PREREQ(3, 8, 7030000) || defined(_MSC_VER))
+#  define HAVE_TARGET_INTRINSICS	1
+#else
+#  define HAVE_TARGET_INTRINSICS	0
+#endif
 
 /*
  * Before gcc 5.1 and clang 3.9, emmintrin.h only defined vectors of signed

--- a/lib/x86/cpu_features.h
+++ b/lib/x86/cpu_features.h
@@ -149,12 +149,14 @@ typedef unsigned char      __v32qu __attribute__((__vector_size__(32)));
 #else
 #  define HAVE_AVX2_NATIVE	0
 #endif
-#define HAVE_AVX2_TARGET \
-	(HAVE_DYNAMIC_X86_CPU_FEATURES && \
-	 (GCC_PREREQ(4, 7) || __has_builtin(__builtin_ia32_psadbw256)))
-#define HAVE_AVX2_INTRIN \
-	(HAVE_INTRIN && \
-	 (HAVE_AVX2_NATIVE || (HAVE_AVX2_TARGET && HAVE_TARGET_INTRINSICS)))
+#if HAVE_AVX2_NATIVE || (HAVE_TARGET_INTRINSICS && \
+			 (GCC_PREREQ(4, 7) || \
+			  __has_builtin(__builtin_ia32_psadbw256) || \
+			  defined(_MSC_VER)))
+#  define HAVE_AVX2_INTRIN	1
+#else
+#  define HAVE_AVX2_INTRIN	0
+#endif
 
 /* BMI2 */
 #ifdef __BMI2__

--- a/lib/x86/cpu_features.h
+++ b/lib/x86/cpu_features.h
@@ -39,13 +39,6 @@
 #  define HAVE_DYNAMIC_X86_CPU_FEATURES	1
 #endif
 
-#ifdef __GNUC__
-#  define HAVE_INTRIN	1
-#else
- /* intrinsics not compatible (e.g. MSVC, or clang in MSVC mode) */
-#  define HAVE_INTRIN	0
-#endif
-
 #define X86_CPU_FEATURE_SSE2		0x00000001
 #define X86_CPU_FEATURE_PCLMUL		0x00000002
 #define X86_CPU_FEATURE_AVX		0x00000004
@@ -163,17 +156,19 @@ typedef unsigned char      __v32qu __attribute__((__vector_size__(32)));
 #endif
 
 /* BMI2 */
-#ifdef __BMI2__
+#if defined(__BMI2__) || (defined(_MSC_VER) && defined(__AVX2__))
 #  define HAVE_BMI2_NATIVE	1
 #else
 #  define HAVE_BMI2_NATIVE	0
 #endif
-#define HAVE_BMI2_TARGET \
-	(HAVE_DYNAMIC_X86_CPU_FEATURES && \
-	 (GCC_PREREQ(4, 7) || __has_builtin(__builtin_ia32_pdep_di)))
-#define HAVE_BMI2_INTRIN \
-	(HAVE_INTRIN && \
-	 (HAVE_BMI2_NATIVE || (HAVE_BMI2_TARGET && HAVE_TARGET_INTRINSICS)))
+#if HAVE_BMI2_NATIVE || (HAVE_TARGET_INTRINSICS && \
+			 (GCC_PREREQ(4, 7) || \
+			  __has_builtin(__builtin_ia32_pdep_di) || \
+			  defined(_MSC_VER)))
+#  define HAVE_BMI2_INTRIN	1
+#else
+#  define HAVE_BMI2_INTRIN	0
+#endif
 
 #endif /* ARCH_X86_32 || ARCH_X86_64 */
 

--- a/lib/x86/crc32_impl.h
+++ b/lib/x86/crc32_impl.h
@@ -52,10 +52,11 @@
  * SSSE3 and SSE4.1 support, and we can use SSSE3 and SSE4.1 intrinsics for
  * efficient handling of partial blocks.  (We *could* compile a variant with
  * PCLMUL+SSSE3+SSE4.1 w/o AVX, but for simplicity we don't currently bother.)
+ *
+ * FIXME: with MSVC, this isn't actually compiled with AVX code generation
+ * enabled yet.  That would require that this be moved to its own .c file.
  */
-#if HAVE_PCLMUL_INTRIN && HAVE_AVX_INTRIN && \
-	((HAVE_PCLMUL_NATIVE && HAVE_AVX_NATIVE) || \
-	 (HAVE_PCLMUL_TARGET && HAVE_AVX_TARGET))
+#if HAVE_PCLMUL_INTRIN && HAVE_AVX_INTRIN
 #  define crc32_x86_pclmul_avx	crc32_x86_pclmul_avx
 #  define SUFFIX			 _pclmul_avx
 #  if HAVE_PCLMUL_NATIVE && HAVE_AVX_NATIVE

--- a/lib/x86/decompress_impl.h
+++ b/lib/x86/decompress_impl.h
@@ -3,7 +3,12 @@
 
 #include "cpu_features.h"
 
-/* BMI2 optimized version */
+/*
+ * BMI2 optimized version
+ *
+ * FIXME: with MSVC, this isn't actually compiled with BMI2 code generation
+ * enabled yet.  That would require that this be moved to its own .c file.
+ */
 #if HAVE_BMI2_INTRIN
 #  define deflate_decompress_bmi2	deflate_decompress_bmi2
 #  define FUNCNAME			deflate_decompress_bmi2


### PR DESCRIPTION
* lib/matchfinder: make MSVC actually recognize the aligned attribute
* lib/x86: support detecting CPU features with MSVC
* lib/x86: make SSE2 adler32 and matchfinder code work with MSVC
* lib/x86: make AVX2 adler32 code work with MSVC
* lib/x86: make PCLMUL crc32 code mostly work with MSVC
* lib/x86: make bmi2 decompression code work (not very well) with MSVC
* lib/x86: remove vector typedefs that are no longer needed
