### PR TITLE
MSVC support for most of lib/arm/ 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,8 +109,11 @@ jobs:
     name: Build (Windows, Visual Studio ${{matrix.toolset}}, ${{matrix.platform}})
     strategy:
       matrix:
-        platform: [x64, Win32]
+        platform: [x64, Win32, ARM64, ARM]
         toolset: [v143, ClangCL]
+        exclude: # Exclude unsupported combinations
+        - platform: ARM
+          toolset: ClangCL
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ You should compile both `lib/*.c` and `lib/*/*.c`.  You don't need to worry
 about excluding irrelevant architecture-specific code, as this is already
 handled in the source files themselves using `#ifdef`s.
 
-It is **strongly** recommended to use either gcc or clang, and to use `-O2`.
+It is strongly recommended to use either gcc or clang, and to use `-O2`.
 
 If you are doing a freestanding build with `-ffreestanding`, you must add
 `-DFREESTANDING` as well (matching what the `CMakeLists.txt` does).

--- a/common_defs.h
+++ b/common_defs.h
@@ -45,6 +45,7 @@
    /* /W4 */
 #  pragma warning(disable : 4100) /* unreferenced formal parameter */
 #  pragma warning(disable : 4127) /* conditional expression is constant */
+#  pragma warning(disable : 4189) /* local variable initialized but not referenced */
 #  pragma warning(disable : 4232) /* nonstandard extension used */
 #  pragma warning(disable : 4245) /* conversion from 'int' to 'unsigned int' */
 #  pragma warning(disable : 4295) /* array too small to include terminating null */

--- a/lib/arm/cpu_features.c
+++ b/lib/arm/cpu_features.c
@@ -167,6 +167,23 @@ static u32 query_arm_cpu_features(void)
 	}
 	return features;
 }
+#elif defined(_WIN32)
+
+#include <windows.h>
+
+static u32 query_arm_cpu_features(void)
+{
+	u32 features = ARM_CPU_FEATURE_NEON;
+
+	if (IsProcessorFeaturePresent(PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE))
+		features |= ARM_CPU_FEATURE_PMULL;
+	if (IsProcessorFeaturePresent(PF_ARM_V8_CRC32_INSTRUCTIONS_AVAILABLE))
+		features |= ARM_CPU_FEATURE_CRC32;
+
+	/* FIXME: detect SHA3 and DOTPROD support too. */
+
+	return features;
+}
 #else
 #error "unhandled case"
 #endif

--- a/lib/arm/cpu_features.h
+++ b/lib/arm/cpu_features.h
@@ -174,14 +174,16 @@ static inline u32 get_arm_cpu_features(void) { return 0; }
 #  else
 #    define HAVE_DOTPROD_NATIVE	0
 #  endif
-#  define HAVE_DOTPROD_TARGET \
+#  if HAVE_DOTPROD_NATIVE || \
 	(HAVE_DYNAMIC_ARM_CPU_FEATURES && \
-	 (GCC_PREREQ(8, 1) || __has_builtin(__builtin_neon_vdotq_v)))
-#  define HAVE_DOTPROD_INTRIN \
-	(HAVE_NEON_INTRIN && (HAVE_DOTPROD_NATIVE || HAVE_DOTPROD_TARGET))
+	 (GCC_PREREQ(8, 1) || __has_builtin(__builtin_neon_vdotq_v) || \
+	  defined(_MSC_VER)))
+#    define HAVE_DOTPROD_INTRIN	1
+#  else
+#    define HAVE_DOTPROD_INTRIN	0
+#  endif
 #else
 #  define HAVE_DOTPROD_NATIVE	0
-#  define HAVE_DOTPROD_TARGET	0
 #  define HAVE_DOTPROD_INTRIN	0
 #endif
 

--- a/lib/arm/cpu_features.h
+++ b/lib/arm/cpu_features.h
@@ -79,20 +79,18 @@ static inline u32 get_arm_cpu_features(void) { return 0; }
 #endif /* !HAVE_DYNAMIC_ARM_CPU_FEATURES */
 
 /* NEON */
-#ifdef __ARM_NEON
+#if defined(__ARM_NEON) || defined(ARCH_ARM64)
 #  define HAVE_NEON_NATIVE	1
 #else
 #  define HAVE_NEON_NATIVE	0
 #endif
-#define HAVE_NEON_TARGET	HAVE_DYNAMIC_ARM_CPU_FEATURES
 /*
  * With both gcc and clang, NEON intrinsics require that the main target has
  * NEON enabled already.  Exception: with gcc 6.1 and later (r230411 for arm32,
  * r226563 for arm64), hardware floating point support is sufficient.
  */
-#if HAVE_INTRIN && \
-	(HAVE_NEON_NATIVE || \
-	 (HAVE_NEON_TARGET && GCC_PREREQ(6, 1) && defined(__ARM_FP)))
+#if HAVE_NEON_NATIVE || \
+	(HAVE_DYNAMIC_ARM_CPU_FEATURES && GCC_PREREQ(6, 1) && defined(__ARM_FP))
 #  define HAVE_NEON_INTRIN	1
 #else
 #  define HAVE_NEON_INTRIN	0

--- a/lib/arm/cpu_features.h
+++ b/lib/arm/cpu_features.h
@@ -34,10 +34,11 @@
 
 #if defined(ARCH_ARM32) || defined(ARCH_ARM64)
 
-#if COMPILER_SUPPORTS_TARGET_FUNCTION_ATTRIBUTE && \
-	!defined(FREESTANDING) && \
-	(defined(__linux__) || \
-	 (defined(ARCH_ARM64) && defined(__APPLE__)))
+#if !defined(FREESTANDING) && \
+    (COMPILER_SUPPORTS_TARGET_FUNCTION_ATTRIBUTE || defined(_MSC_VER)) && \
+    (defined(__linux__) || \
+     (defined(__APPLE__) && defined(ARCH_ARM64)) || \
+     (defined(_WIN32) && defined(ARCH_ARM64)))
 #  undef HAVE_DYNAMIC_ARM_CPU_FEATURES
 #  define HAVE_DYNAMIC_ARM_CPU_FEATURES	1
 #endif

--- a/lib/arm/matchfinder_impl.h
+++ b/lib/arm/matchfinder_impl.h
@@ -36,11 +36,7 @@ static forceinline void
 matchfinder_init_neon(mf_pos_t *data, size_t size)
 {
 	int16x8_t *p = (int16x8_t *)data;
-	int16x8_t v = (int16x8_t) {
-		MATCHFINDER_INITVAL, MATCHFINDER_INITVAL, MATCHFINDER_INITVAL,
-		MATCHFINDER_INITVAL, MATCHFINDER_INITVAL, MATCHFINDER_INITVAL,
-		MATCHFINDER_INITVAL, MATCHFINDER_INITVAL,
-	};
+	int16x8_t v = vdupq_n_s16(MATCHFINDER_INITVAL);
 
 	STATIC_ASSERT(MATCHFINDER_MEM_ALIGNMENT % sizeof(*p) == 0);
 	STATIC_ASSERT(MATCHFINDER_SIZE_ALIGNMENT % (4 * sizeof(*p)) == 0);
@@ -61,12 +57,7 @@ static forceinline void
 matchfinder_rebase_neon(mf_pos_t *data, size_t size)
 {
 	int16x8_t *p = (int16x8_t *)data;
-	int16x8_t v = (int16x8_t) {
-		(u16)-MATCHFINDER_WINDOW_SIZE, (u16)-MATCHFINDER_WINDOW_SIZE,
-		(u16)-MATCHFINDER_WINDOW_SIZE, (u16)-MATCHFINDER_WINDOW_SIZE,
-		(u16)-MATCHFINDER_WINDOW_SIZE, (u16)-MATCHFINDER_WINDOW_SIZE,
-		(u16)-MATCHFINDER_WINDOW_SIZE, (u16)-MATCHFINDER_WINDOW_SIZE,
-	};
+	int16x8_t v = vdupq_n_s16((u16)-MATCHFINDER_WINDOW_SIZE);
 
 	STATIC_ASSERT(MATCHFINDER_MEM_ALIGNMENT % sizeof(*p) == 0);
 	STATIC_ASSERT(MATCHFINDER_SIZE_ALIGNMENT % (4 * sizeof(*p)) == 0);

--- a/scripts/android_build.sh
+++ b/scripts/android_build.sh
@@ -6,14 +6,14 @@ SCRIPTDIR="$(dirname "$0")"
 BUILDDIR="$SCRIPTDIR/../build"
 API_LEVEL=28
 ARCH=arm64
-CFLAGS=
+export CFLAGS=${CFLAGS:-}
 ENABLE_CRC=false
 ENABLE_CRYPTO=false
 NDKDIR=$HOME/android-ndk-r23b
 
 usage() {
 	cat << EOF
-Usage: $0 [OPTION]... -- [MAKE_TARGET]...
+Usage: $0 [OPTION]...
 Build libdeflate for Android.
 
   --api-level=LEVEL    Android API level to target (default: $API_LEVEL)
@@ -71,7 +71,7 @@ case "$ARCH" in
 arm|arm32|aarch32|armeabi-v7a)
 	ANDROID_ABI=armeabi-v7a
 	if $ENABLE_CRC || $ENABLE_CRYPTO; then
-		export CFLAGS="-march=armv8-a"
+		CFLAGS+=" -march=armv8-a"
 		if $ENABLE_CRC; then
 			CFLAGS+=" -mcrc"
 		else
@@ -94,7 +94,7 @@ arm64|aarch64|arm64-v8a)
 		features+="+crypto"
 	fi
 	if [ -n "$features" ]; then
-		export CFLAGS="-march=armv8-a$features"
+		CFLAGS+=" -march=armv8-a$features"
 	fi
 	;;
 x86)

--- a/scripts/android_tests.sh
+++ b/scripts/android_tests.sh
@@ -59,10 +59,11 @@ android_build_and_test() {
 	fi
 }
 
-for arch in arm32 arm64; do
-	android_build_and_test --arch=$arch
-	android_build_and_test --arch=$arch --enable-crc
-	android_build_and_test --arch=$arch --enable-crypto
-	android_build_and_test --arch=$arch --enable-crc --enable-crypto
-done
+android_build_and_test --arch=arm32
+android_build_and_test --arch=arm32 --enable-crc
+android_build_and_test --arch=arm64
+android_build_and_test --arch=arm64 --enable-crc
+android_build_and_test --arch=arm64 --enable-crypto
+android_build_and_test --arch=arm64 --enable-crc --enable-crypto
+
 echo "Android tests passed"


### PR DESCRIPTION
* android_build.sh: accept CFLAGS from environment
* android_tests.sh: don't enable crypto on arm32
* lib/arm: partially support detecting CPU features on Windows
* lib/arm: make NEON adler32 and matchfinder code work with MSVC
* lib/arm: make dotprod adler32 code work with MSVC
* lib/arm: make crc32 code work with MSVC
* README: un-bold "strongly"
