### PR TITLE
lib/arm/cpu_features: re-disable crc32 with buggy gcc versions

### DIFF
--- a/lib/arm/cpu_features.h
+++ b/lib/arm/cpu_features.h
@@ -137,7 +137,7 @@ static inline u32 get_arm_cpu_features(void) { return 0; }
  */
 #if HAVE_CRC32_NATIVE || \
 	(HAVE_DYNAMIC_ARM_CPU_FEATURES && \
-	 (__has_builtin(__builtin_arm_crc32b) || \
+	 ((__has_builtin(__builtin_arm_crc32b) && !GCC_PREREQ(1, 0)) || \
 	  GCC_PREREQ(11, 3) || \
 	  (GCC_PREREQ(10, 4) && !GCC_PREREQ(11, 0)) || \
 	  (GCC_PREREQ(9, 5) && !GCC_PREREQ(10, 0)) || \


### PR DESCRIPTION
Some gcc versions (e.g. 10.2.1) return true for
__has_builtin(__builtin_arm_crc32b) but are affected by the bug mentioned in the comment above the definition of HAVE_CRC32_INTRIN. This causes a build error.  Make it so that the gcc version check is still done when __has_builtin(__builtin_arm_crc32b).

Fixes https://github.com/ebiggers/libdeflate/issues/276
Fixes: 84c76f6f2cf5 ("lib/arm: make crc32 code work with MSVC")