### PR TITLE
deflate_decompress: return error when too many codeword lengths

### DIFF
--- a/lib/decompress_template.h
+++ b/lib/decompress_template.h
@@ -179,11 +179,11 @@ next_block:
 			/* Run-length encoded codeword lengths */
 
 			/*
-			 * Note: we don't need verify that the repeat count
-			 * doesn't overflow the number of elements, since we've
-			 * sized the lens array to have enough extra space to
-			 * allow for the worst-case overrun (138 zeroes when
-			 * only 1 length was remaining).
+			 * Note: we don't need to immediately verify that the
+			 * repeat count doesn't overflow the number of elements,
+			 * since we've sized the lens array to have enough extra
+			 * space to allow for the worst-case overrun (138 zeroes
+			 * when only 1 length was remaining).
 			 *
 			 * In the case of the small repeat counts (presyms 16
 			 * and 17), it is fastest to always write the maximum
@@ -240,6 +240,9 @@ next_block:
 				i += rep_count;
 			}
 		} while (i < num_litlen_syms + num_offset_syms);
+
+		/* Unnecessary, but check this for consistency with zlib. */
+		SAFETY_CHECK(i == num_litlen_syms + num_offset_syms);
 
 	} else if (block_type == DEFLATE_BLOCKTYPE_UNCOMPRESSED) {
 		u16 len, nlen;

--- a/programs/CMakeLists.txt
+++ b/programs/CMakeLists.txt
@@ -89,6 +89,7 @@ if(LIBDEFLATE_BUILD_TESTS)
         test_checksums
         test_custom_malloc
         test_incomplete_codes
+        test_invalid_streams
         test_litrunlen_overflow
         test_overread
         test_slow_decompression

--- a/programs/test_invalid_streams.c
+++ b/programs/test_invalid_streams.c
@@ -1,0 +1,130 @@
+/*
+ * test_invalid_streams.c
+ *
+ * Test that invalid DEFLATE streams are rejected with LIBDEFLATE_BAD_DATA.
+ *
+ * This isn't actually very important, since DEFLATE doesn't have built-in error
+ * detection, so corruption of a DEFLATE stream can only be reliably detected
+ * using a separate checksum anyway.  As long as the DEFLATE decompressor
+ * handles all streams safely (no crashes, etc.), in practice it is fine for it
+ * to automatically remap invalid streams to valid streams, instead of returning
+ * an error.  Corruption detection is the responsibility of the zlib or gzip
+ * layer, or the application when an external checksum is used.
+ *
+ * Nevertheless, to reduce surprises when people intentionally compare zlib's
+ * and libdeflate's handling of invalid DEFLATE streams, libdeflate implements
+ * zlib's strict behavior when decoding DEFLATE, except when it would have a
+ * significant performance cost.
+ */
+
+#include "test_util.h"
+
+static void
+assert_decompression_error(const u8 *in, size_t in_nbytes)
+{
+	struct libdeflate_decompressor *d;
+	z_stream z;
+	u8 out[128];
+	const size_t out_nbytes_avail = sizeof(out);
+	size_t actual_out_nbytes;
+	enum libdeflate_result res;
+
+	/* libdeflate */
+	d = libdeflate_alloc_decompressor();
+	ASSERT(d != NULL);
+	res = libdeflate_deflate_decompress(d, in, in_nbytes,
+					    out, out_nbytes_avail,
+					    &actual_out_nbytes);
+	ASSERT(res == LIBDEFLATE_BAD_DATA);
+	libdeflate_free_decompressor(d);
+
+	/* zlib, as a control */
+	memset(&z, 0, sizeof(z));
+	res = inflateInit2(&z, -15);
+	ASSERT(res == Z_OK);
+	z.next_in = (void *)in;
+	z.avail_in = in_nbytes;
+	z.next_out = (void *)out;
+	z.avail_out = out_nbytes_avail;
+	res = inflate(&z, Z_FINISH);
+	ASSERT(res == Z_DATA_ERROR);
+	inflateEnd(&z);
+}
+
+/*
+ * Test that DEFLATE decompression returns an error if a block header contains
+ * too many encoded litlen and offset codeword lengths.
+ */
+static void
+test_too_many_codeword_lengths(void)
+{
+	u8 in[128];
+	struct output_bitstream os = { .next = in, .end = in + sizeof(in) };
+	int i;
+
+	ASSERT(put_bits(&os, 1, 1));	/* BFINAL: 1 */
+	ASSERT(put_bits(&os, 2, 2));	/* BTYPE: DYNAMIC_HUFFMAN */
+
+	/*
+	 * Litlen code:
+	 *	litlensym_255			len=1 codeword=0
+	 *	litlensym_256 (end-of-block)	len=1 codeword=1
+	 * Offset code:
+	 *	(empty)
+	 *
+	 * Litlen and offset codeword lengths:
+	 *	[0..254] = 0	presym_{18,18}
+	 *	[255]	 = 1	presym_1
+	 *	[256]	 = 1	presym_1
+	 *	[257...] = 0	presym_18 [TOO MANY]
+	 *
+	 * Precode:
+	 *	presym_1	len=1 codeword=0
+	 *	presym_18	len=1 codeword=1
+	 */
+
+	ASSERT(put_bits(&os, 0, 5));	/* num_litlen_syms: 0 + 257 */
+	ASSERT(put_bits(&os, 0, 5));	/* num_offset_syms: 0 + 1 */
+	ASSERT(put_bits(&os, 14, 4));	/* num_explicit_precode_lens: 14 + 4 */
+
+	/*
+	 * Precode codeword lengths: order is
+	 * [16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15]
+	 */
+	for (i = 0; i < 2; i++)		/* presym_{16,17}: len=0 */
+		ASSERT(put_bits(&os, 0, 3));
+	ASSERT(put_bits(&os, 1, 3));	/* presym_18: len=1 */
+	ASSERT(put_bits(&os, 0, 3));	/* presym_0: len=0 */
+	for (i = 0; i < 13; i++)	/* presym_{8,...,14}: len=0 */
+		ASSERT(put_bits(&os, 0, 3));
+	ASSERT(put_bits(&os, 1, 3));	/* presym_1: len=1 */
+
+	/* Litlen and offset codeword lengths */
+	ASSERT(put_bits(&os, 0x1, 1) &&	/* presym_18, 128 zeroes */
+	       put_bits(&os, 117, 7));
+	ASSERT(put_bits(&os, 0x1, 1) &&	/* presym_18, 127 zeroes */
+	       put_bits(&os, 116, 7));
+	ASSERT(put_bits(&os, 0x0, 1));	/* presym_1 */
+	ASSERT(put_bits(&os, 0x0, 1));	/* presym_1 */
+	ASSERT(put_bits(&os, 0x1, 1) &&	/* presym_18, 128 zeroes [TOO MANY] */
+	       put_bits(&os, 117, 7));
+
+	/* Literal */
+	ASSERT(put_bits(&os, 0x0, 0));	/* litlensym_255 */
+
+	/* End of block */
+	ASSERT(put_bits(&os, 0x1, 1));	/* litlensym_256 */
+
+	ASSERT(flush_bits(&os));
+
+	assert_decompression_error(in, os.next - in);
+}
+
+int
+tmain(int argc, tchar *argv[])
+{
+	begin_program(argv);
+
+	test_too_many_codeword_lengths();
+	return 0;
+}


### PR DESCRIPTION
When there are more encoded litlen and offset codeword lengths than there are supposed to be based on the earlier fields, return LIBDEFLATE_BAD_DATA instead of ignoring the extra lengths.

This isn't very important, but this aligns the behavior with zlib.

Also add a regression test for this change.

Update https://github.com/ebiggers/libdeflate/issues/288