### PR TITLE
Improved support for compilation without official build system

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,3 +8,5 @@ task:
     - cmake -B build -DLIBDEFLATE_BUILD_TESTS=1
     - cmake --build build
     - ctest --test-dir build
+    # Direct compilation without official build system
+    - cc -O2 -Wall -Werror lib/*.c lib/*/*.c programs/gzip.c programs/prog_util.c programs/tgetopt.c -o libdeflate-gzip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y clang llvm libz-dev valgrind
     - run: scripts/run_tests.sh
+    - name: Direct compilation without official build system
+      run: $CC -O2 -Wall -Werror lib/*{,/*}.c programs/{gzip,prog_util,tgetopt}.c -o libdeflate-gzip
 
   other-arch-build-and-test:
     name: Build and test (${{ matrix.arch }}, Debian Bullseye, ${{ matrix.compiler }})
@@ -54,6 +56,8 @@ jobs:
     - run: cmake --build build --verbose
     - run: DESTDIR=build/install cmake --install build --verbose
     - run: ctest --test-dir build
+    - name: Direct compilation without official build system
+      run: cc -O2 -Wall -Werror lib/*{,/*}.c programs/{gzip,prog_util,tgetopt}.c -o libdeflate-gzip
 
   windows-msys2-build-and-test:
     name: Build and test (Windows, MSYS2, ${{matrix.sys}})
@@ -85,6 +89,8 @@ jobs:
     - run: cmake --build build --verbose
     - run: cmake --install build --verbose
     - run: ctest --test-dir build
+    - name: Direct compilation without official build system
+      run: cc -O2 -Wall -Werror -municode lib/*{,/*}.c programs/{gzip,prog_util,tgetopt}.c -o libdeflate-gzip.exe
 
   windows-visualstudio-build-and-test:
     name: Build and test (Windows, Visual Studio ${{matrix.toolset}}, ${{matrix.platform.vs}})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,10 +159,6 @@ if(LIBDEFLATE_GZIP_SUPPORT)
     endif()
 endif()
 
-if(NOT MSVC)
-    list(APPEND LIB_COMPILE_DEFINITIONS _ANSI_SOURCE)
-endif()
-
 if(LIBDEFLATE_FREESTANDING)
     list(APPEND LIB_COMPILE_OPTIONS -ffreestanding -nostdlib)
     list(APPEND LIB_LINK_LIBRARIES -ffreestanding -nostdlib)

--- a/common_defs.h
+++ b/common_defs.h
@@ -28,6 +28,8 @@
 #ifndef COMMON_DEFS_H
 #define COMMON_DEFS_H
 
+#include "libdeflate.h"
+
 #include <stdbool.h>
 #include <stddef.h>	/* for size_t */
 #include <stdint.h>

--- a/lib/adler32.c
+++ b/lib/adler32.c
@@ -26,7 +26,6 @@
  */
 
 #include "lib_common.h"
-#include "libdeflate.h"
 
 /* The Adler-32 divisor, or "base", value */
 #define DIVISOR 65521

--- a/lib/arm/cpu_features.c
+++ b/lib/arm/cpu_features.c
@@ -31,8 +31,9 @@
  */
 
 #ifdef __APPLE__
-#undef _ANSI_SOURCE
-#define _DARWIN_C_SOURCE /* for sysctlbyname() */
+#  undef _ANSI_SOURCE
+#  undef _DARWIN_C_SOURCE
+#  define _DARWIN_C_SOURCE /* for sysctlbyname() */
 #endif
 
 #include "../cpu_features_common.h" /* must be included first */

--- a/lib/cpu_features_common.h
+++ b/lib/cpu_features_common.h
@@ -29,9 +29,11 @@
 #define LIB_CPU_FEATURES_COMMON_H
 
 #if defined(TEST_SUPPORT__DO_NOT_USE) && !defined(FREESTANDING)
-#  undef _ANSI_SOURCE	/* for strdup() and strtok_r() */
+   /* for strdup() and strtok_r() */
+#  undef _ANSI_SOURCE
 #  ifndef __APPLE__
-#    define _GNU_SOURCE 1
+#    undef _GNU_SOURCE
+#    define _GNU_SOURCE
 #  endif
 #  include <stdio.h>
 #  include <stdlib.h>

--- a/lib/crc32.c
+++ b/lib/crc32.c
@@ -169,7 +169,6 @@
  */
 
 #include "lib_common.h"
-#include "libdeflate.h"
 #include "crc32_multipliers.h"
 #include "crc32_tables.h"
 

--- a/lib/deflate_compress.c
+++ b/lib/deflate_compress.c
@@ -28,8 +28,6 @@
 #include "deflate_compress.h"
 #include "deflate_constants.h"
 
-#include "libdeflate.h"
-
 /******************************************************************************/
 
 /*

--- a/lib/deflate_compress.c
+++ b/lib/deflate_compress.c
@@ -800,8 +800,7 @@ heapify_array(u32 A[], unsigned length)
  * Sort the array 'A', which contains 'length' unsigned 32-bit integers.
  *
  * Note: name this function heap_sort() instead of heapsort() to avoid colliding
- * with heapsort() from stdlib.h on BSD-derived systems --- though this isn't
- * necessary when compiling with -D_ANSI_SOURCE, which is the better solution.
+ * with heapsort() from stdlib.h on BSD-derived systems.
  */
 static void
 heap_sort(u32 A[], unsigned length)

--- a/lib/deflate_decompress.c
+++ b/lib/deflate_decompress.c
@@ -45,8 +45,6 @@
 #include "lib_common.h"
 #include "deflate_constants.h"
 
-#include "libdeflate.h"
-
 /*
  * If the expression passed to SAFETY_CHECK() evaluates to false, then the
  * decompression routine immediately returns LIBDEFLATE_BAD_DATA, indicating the

--- a/lib/gzip_compress.c
+++ b/lib/gzip_compress.c
@@ -28,8 +28,6 @@
 #include "deflate_compress.h"
 #include "gzip_constants.h"
 
-#include "libdeflate.h"
-
 LIBDEFLATEAPI size_t
 libdeflate_gzip_compress(struct libdeflate_compressor *c,
 			 const void *in, size_t in_nbytes,

--- a/lib/gzip_decompress.c
+++ b/lib/gzip_decompress.c
@@ -28,8 +28,6 @@
 #include "lib_common.h"
 #include "gzip_constants.h"
 
-#include "libdeflate.h"
-
 LIBDEFLATEAPI enum libdeflate_result
 libdeflate_gzip_decompress_ex(struct libdeflate_decompressor *d,
 			      const void *in, size_t in_nbytes,

--- a/lib/lib_common.h
+++ b/lib/lib_common.h
@@ -39,6 +39,8 @@
 
 #define LIBDEFLATEAPI	LIBDEFLATE_EXPORT_SYM LIBDEFLATE_ALIGN_STACK
 
+#include "../libdeflate.h"
+
 void *libdeflate_malloc(size_t size);
 void libdeflate_free(void *ptr);
 

--- a/lib/lib_common.h
+++ b/lib/lib_common.h
@@ -5,8 +5,6 @@
 #ifndef LIB_LIB_COMMON_H
 #define LIB_LIB_COMMON_H
 
-#include "../common_defs.h"
-
 #ifdef LIBDEFLATE_H
  /*
   * When building the library, LIBDEFLATEAPI needs to be defined properly before
@@ -39,7 +37,7 @@
 
 #define LIBDEFLATEAPI	LIBDEFLATE_EXPORT_SYM LIBDEFLATE_ALIGN_STACK
 
-#include "../libdeflate.h"
+#include "../common_defs.h"
 
 void *libdeflate_malloc(size_t size);
 void libdeflate_free(void *ptr);

--- a/lib/utils.c
+++ b/lib/utils.c
@@ -27,8 +27,6 @@
 
 #include "lib_common.h"
 
-#include "libdeflate.h"
-
 #ifdef FREESTANDING
 #  define malloc NULL
 #  define free NULL

--- a/lib/zlib_compress.c
+++ b/lib/zlib_compress.c
@@ -28,8 +28,6 @@
 #include "deflate_compress.h"
 #include "zlib_constants.h"
 
-#include "libdeflate.h"
-
 LIBDEFLATEAPI size_t
 libdeflate_zlib_compress(struct libdeflate_compressor *c,
 			 const void *in, size_t in_nbytes,

--- a/lib/zlib_decompress.c
+++ b/lib/zlib_decompress.c
@@ -28,8 +28,6 @@
 #include "lib_common.h"
 #include "zlib_constants.h"
 
-#include "libdeflate.h"
-
 LIBDEFLATEAPI enum libdeflate_result
 libdeflate_zlib_decompress_ex(struct libdeflate_decompressor *d,
 			      const void *in, size_t in_nbytes,

--- a/programs/CMakeLists.txt
+++ b/programs/CMakeLists.txt
@@ -1,9 +1,14 @@
 include(CheckSymbolExists)
 
 # Check for the availability of OS functionality and generate the config.h file.
-if(NOT MSVC)
-    set(CMAKE_REQUIRED_DEFINITIONS
-        -D_POSIX_C_SOURCE=200809L -D_FILE_OFFSET_BITS=64)
+#
+# Keep CMAKE_REQUIRED_DEFINITIONS in sync with what prog_util.h does.
+if(LINUX)
+    set(CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE -D_POSIX_C_SOURCE=200809L)
+elseif(APPLE)
+    set(CMAKE_REQUIRED_DEFINITIONS -D_DARWIN_C_SOURCE -U_POSIX_C_SOURCE)
+else()
+    set(CMAKE_REQUIRED_DEFINITIONS -U_POSIX_C_SOURCE)
 endif()
 check_symbol_exists(clock_gettime "time.h" HAVE_CLOCK_GETTIME)
 check_symbol_exists(futimens "fcntl.h;sys/stat.h" HAVE_FUTIMENS)
@@ -34,8 +39,6 @@ if(WIN32)
         target_compile_definitions(libdeflate_prog_utils PUBLIC UNICODE _UNICODE)
     endif()
 endif()
-target_compile_definitions(libdeflate_prog_utils PUBLIC
-                           ${CMAKE_REQUIRED_DEFINITIONS})
 
 # Build and install libdeflate-gzip and its alias libdeflate-gunzip.
 if(LIBDEFLATE_BUILD_GZIP)

--- a/programs/CMakeLists.txt
+++ b/programs/CMakeLists.txt
@@ -7,7 +7,6 @@ if(NOT MSVC)
 endif()
 check_symbol_exists(clock_gettime "time.h" HAVE_CLOCK_GETTIME)
 check_symbol_exists(futimens "fcntl.h;sys/stat.h" HAVE_FUTIMENS)
-check_symbol_exists(futimes "sys/time.h" HAVE_FUTIMES)
 check_symbol_exists(posix_fadvise "fcntl.h" HAVE_POSIX_FADVISE)
 check_symbol_exists(posix_madvise "sys/mman.h" HAVE_POSIX_MADVISE)
 check_c_source_compiles("#include <sys/types.h>

--- a/programs/config.h.in
+++ b/programs/config.h.in
@@ -7,9 +7,6 @@
 /* Is the futimens() function available? */
 #cmakedefine HAVE_FUTIMENS
 
-/* Is the futimes() function available? */
-#cmakedefine HAVE_FUTIMES
-
 /* Is the posix_fadvise() function available? */
 #cmakedefine HAVE_POSIX_FADVISE
 

--- a/programs/gzip.c
+++ b/programs/gzip.c
@@ -25,10 +25,6 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#ifdef __sun
-#  define __EXTENSIONS__ /* for futimens() */
-#endif
-
 #include "prog_util.h"
 
 #include <errno.h>
@@ -356,20 +352,16 @@ restore_timestamps(struct file_stream *out, const tchar *newpath,
 {
 	int ret;
 #ifdef __APPLE__
-	struct timespec times[2] = {
-		{ stbuf->st_atime, stbuf->st_atimensec },
-		{ stbuf->st_mtime, stbuf->st_mtimensec },
-	};
+	struct timespec times[2] = { stbuf->st_atimespec, stbuf->st_mtimespec };
+
 	ret = futimens(out->fd, times);
 #elif defined(HAVE_FUTIMENS) && defined(HAVE_STAT_NANOSECOND_PRECISION)
-	struct timespec times[2] = {
-		stbuf->st_atim, stbuf->st_mtim,
-	};
+	struct timespec times[2] = { stbuf->st_atim, stbuf->st_mtim };
+
 	ret = futimens(out->fd, times);
 #else
-	struct tutimbuf times = {
-		stbuf->st_atime, stbuf->st_mtime,
-	};
+	struct tutimbuf times = { stbuf->st_atime, stbuf->st_mtime };
+
 	ret = tutime(newpath, &times);
 #endif
 	if (ret != 0)

--- a/programs/gzip.c
+++ b/programs/gzip.c
@@ -366,12 +366,6 @@ restore_timestamps(struct file_stream *out, const tchar *newpath,
 		stbuf->st_atim, stbuf->st_mtim,
 	};
 	ret = futimens(out->fd, times);
-#elif defined(HAVE_FUTIMES) && defined(HAVE_STAT_NANOSECOND_PRECISION)
-	struct timeval times[2] = {
-		{ stbuf->st_atim.tv_sec, stbuf->st_atim.tv_nsec / 1000, },
-		{ stbuf->st_mtim.tv_sec, stbuf->st_mtim.tv_nsec / 1000, },
-	};
-	ret = futimes(out->fd, times);
 #else
 	struct tutimbuf times = {
 		stbuf->st_atime, stbuf->st_mtime,

--- a/programs/gzip.c
+++ b/programs/gzip.c
@@ -355,7 +355,9 @@ restore_timestamps(struct file_stream *out, const tchar *newpath,
 	struct timespec times[2] = { stbuf->st_atimespec, stbuf->st_mtimespec };
 
 	ret = futimens(out->fd, times);
-#elif defined(HAVE_FUTIMENS) && defined(HAVE_STAT_NANOSECOND_PRECISION)
+#elif (defined(HAVE_FUTIMENS) && defined(HAVE_STAT_NANOSECOND_PRECISION)) || \
+	/* fallback detection method for direct compilation */ \
+	(!defined(HAVE_CONFIG_H) && defined(UTIME_NOW))
 	struct timespec times[2] = { stbuf->st_atim, stbuf->st_mtim };
 
 	ret = futimens(out->fd, times);

--- a/programs/prog_util.c
+++ b/programs/prog_util.c
@@ -25,12 +25,6 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#ifdef __APPLE__
-/* for O_NOFOLLOW */
-#  undef _POSIX_C_SOURCE
-#  define _DARWIN_C_SOURCE
-#endif
-
 #include "prog_util.h"
 
 #include <errno.h>

--- a/programs/prog_util.c
+++ b/programs/prog_util.c
@@ -202,7 +202,10 @@ xopen_for_read(const tchar *path, bool symlink_ok, struct file_stream *strm)
 		return -1;
 	}
 
-#if defined(HAVE_POSIX_FADVISE) && (O_SEQUENTIAL == 0)
+#if O_SEQUENTIAL == 0 && \
+	(defined(HAVE_POSIX_FADVISE) || \
+	 /* fallback detection method for direct compilation */ \
+	 (!defined(HAVE_CONFIG_H) && defined(POSIX_FADV_SEQUENTIAL)))
 	(void)posix_fadvise(strm->fd, 0, 0, POSIX_FADV_SEQUENTIAL);
 #endif
 
@@ -366,7 +369,9 @@ map_file_contents(struct file_stream *strm, u64 size)
 		return -1;
 	}
 
-#ifdef HAVE_POSIX_MADVISE
+#if defined(HAVE_POSIX_MADVISE) || \
+	/* fallback detection method for direct compilation */ \
+	(!defined(HAVE_CONFIG_H) && defined(POSIX_MADV_SEQUENTIAL))
 	(void)posix_madvise(strm->mmap_mem, size, POSIX_MADV_SEQUENTIAL);
 #endif
 	strm->mmap_token = strm; /* anything that's not NULL */

--- a/programs/prog_util.h
+++ b/programs/prog_util.h
@@ -97,7 +97,7 @@
 #  include "config.h"
 #endif
 
-#include "../libdeflate.h"
+#include "../common_defs.h"
 
 #include <inttypes.h>
 #include <limits.h>
@@ -107,8 +107,6 @@
 #ifndef _WIN32
 #  include <sys/types.h>
 #endif
-
-#include "../common_defs.h"
 
 #if defined(__GNUC__) || __has_attribute(format)
 # define _printf(str_idx, args_idx)	\

--- a/programs/prog_util.h
+++ b/programs/prog_util.h
@@ -97,7 +97,7 @@
 #  include "config.h"
 #endif
 
-#include "libdeflate.h"
+#include "../libdeflate.h"
 
 #include <inttypes.h>
 #include <limits.h>

--- a/programs/test_checksums.c
+++ b/programs/test_checksums.c
@@ -5,10 +5,10 @@
  * results as their zlib equivalents.
  */
 
+#include "test_util.h"
+
 #include <stdlib.h>
 #include <time.h>
-
-#include "test_util.h"
 
 static unsigned int rng_seed;
 

--- a/programs/test_util.c
+++ b/programs/test_util.c
@@ -148,7 +148,9 @@ timer_ticks(void)
 
 	QueryPerformanceCounter(&count);
 	return count.QuadPart;
-#elif defined(HAVE_CLOCK_GETTIME)
+#elif defined(HAVE_CLOCK_GETTIME) || \
+	/* fallback detection method for direct compilation */ \
+	(!defined(HAVE_CONFIG_H) && defined(CLOCK_MONOTONIC))
 	struct timespec ts;
 
 	clock_gettime(CLOCK_MONOTONIC, &ts);

--- a/programs/test_util.c
+++ b/programs/test_util.c
@@ -25,16 +25,6 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#ifndef _WIN32
-/* for MAP_ANONYMOUS or MAP_ANON, which unfortunately aren't part of POSIX... */
-#  undef _POSIX_C_SOURCE
-#  ifdef __APPLE__
-#    define _DARWIN_C_SOURCE
-#  elif defined(__linux__)
-#    define _GNU_SOURCE
-#  endif
-#endif
-
 #include "test_util.h"
 
 #include <fcntl.h>

--- a/programs/test_util.h
+++ b/programs/test_util.h
@@ -28,7 +28,7 @@
 #ifndef PROGRAMS_TEST_UTIL_H
 #define PROGRAMS_TEST_UTIL_H
 
-#include "prog_util.h"
+#include "prog_util.h" /* must be included first */
 
 #include <zlib.h> /* for comparison purposes */
 


### PR DESCRIPTION
* programs: drop support for futimes()
* programs: define feature macros automatically in the source code
* programs: use fallback function detection methods for direct compilation
* programs: include libdeflate.h via relative path
* lib: don't use _ANSI_SOURCE
* lib: include libdeflate.h via relative path
* Include libdeflate.h from common_defs.h
* CI: test direct compilation without official build system
