### PR TITLE
Fix build error on armv6kz and armv7e-m archs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,33 @@ jobs:
         cmake --build build --verbose
         DESTDIR=build/install cmake --install build --verbose
 
+  cpu-features-regression-tests:
+    name: Test building adler32.c and crc32.c with various flags
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu
+    - name: Compile tests
+      run: |
+        for file in lib/adler32.c lib/crc32.c; do
+          for arch in armv4 armv4t armv5t armv5te armv5tej armv6 armv6j armv6k \
+                      armv6z armv6kz armv6zk armv6t2; do
+            echo "arm32, -march=$arch, file=$file"
+            arm-linux-gnueabihf-gcc -c -march=$arch -mfpu=vfp -marm \
+                -O0 -Wall -Werror $file
+          done
+          for arch in armv7 armv7-a armv7ve armv7-r armv7-m armv7e-m; do
+            echo "arm32, -march=$arch, file=$file"
+            arm-linux-gnueabihf-gcc -c -march=$arch -mfpu=vfp \
+                -O0 -Wall -Werror $file
+          done
+          echo "arm64, -mcpu=emag"
+          aarch64-linux-gnu-gcc -c -mcpu=emag -O0 -Wall -Werror $file
+        done
+
   fuzz-with-libFuzzer:
     name: Fuzz with libFuzzer (${{matrix.target}} ${{matrix.sanitizer}})
     strategy:

--- a/lib/arm/cpu_features.h
+++ b/lib/arm/cpu_features.h
@@ -164,10 +164,19 @@ static inline u32 get_arm_cpu_features(void) { return 0; }
      * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=104439.  We use the second
      * set of prerequisites, as they are stricter and we have no way to detect
      * the binutils version directly from a C source file.
+     *
+     * Also exclude the cases where the main target arch is armv6kz or armv7e-m.
+     * In those cases, gcc doesn't let functions that use the main arch be
+     * inlined into functions that are targeted to armv8-a+crc.  (armv8-a is
+     * necessary for crc to be accepted at all.)  That causes build errors.
+     * This issue happens for these specific sub-archs because they are not a
+     * subset of armv8-a.  Note: clang does not have this limitation.
      */
 #    if (GCC_PREREQ(11, 3) || \
 	 (GCC_PREREQ(10, 4) && !GCC_PREREQ(11, 0)) || \
-	 (GCC_PREREQ(9, 5) && !GCC_PREREQ(10, 0)))
+	 (GCC_PREREQ(9, 5) && !GCC_PREREQ(10, 0))) && \
+	!defined(__ARM_ARCH_6KZ__) && \
+	!defined(__ARM_ARCH_7EM__)
 #      define HAVE_CRC32_INTRIN	1
 #    endif
 #  elif __has_builtin(__builtin_arm_crc32b)


### PR DESCRIPTION
* lib/arm/cpu_features: break up the HAVE_CRC32_INTRIN logic
* lib/arm/cpu_features: fix build error on armv6kz and armv7e-m archs
* ci.yml: test building adler32.c and crc32.c with various flags