### PR TITLE
lib/arm/crc32_impl: fix build error with Debian armhf gcc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,20 +220,21 @@ jobs:
         sudo apt-get install -y gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu
     - name: Compile tests
       run: |
+        cflags="-O0 -Wall -Werror"
         for file in lib/adler32.c lib/crc32.c; do
+          echo "arm32, default options, file=$file"
+          arm-linux-gnueabihf-gcc -c $cflags $file
           for arch in armv4 armv4t armv5t armv5te armv5tej armv6 armv6j armv6k \
                       armv6z armv6kz armv6zk armv6t2; do
             echo "arm32, -march=$arch, file=$file"
-            arm-linux-gnueabihf-gcc -c -march=$arch -mfpu=vfp -marm \
-                -O0 -Wall -Werror $file
+            arm-linux-gnueabihf-gcc -c -march=$arch -mfpu=vfp -marm $cflags $file
           done
           for arch in armv7 armv7-a armv7ve armv7-r armv7-m armv7e-m; do
             echo "arm32, -march=$arch, file=$file"
-            arm-linux-gnueabihf-gcc -c -march=$arch -mfpu=vfp \
-                -O0 -Wall -Werror $file
+            arm-linux-gnueabihf-gcc -c -march=$arch -mfpu=vfp $cflags $file
           done
           echo "arm64, -mcpu=emag"
-          aarch64-linux-gnu-gcc -c -mcpu=emag -O0 -Wall -Werror $file
+          aarch64-linux-gnu-gcc -c -mcpu=emag $cflags $file
         done
 
   fuzz-with-libFuzzer:

--- a/lib/arm/crc32_impl.h
+++ b/lib/arm/crc32_impl.h
@@ -51,6 +51,13 @@
 #    ifdef ARCH_ARM32
 #      ifdef __clang__
 #        define ATTRIBUTES	_target_attribute("armv8-a,crc")
+#      elif defined(__ARM_PCS_VFP)
+	 /*
+	  * +simd is needed to avoid a "selected architecture lacks an FPU"
+	  * error with Debian arm-linux-gnueabihf-gcc when -mfpu is not
+	  * explicitly specified on the command line.
+	  */
+#        define ATTRIBUTES	_target_attribute("arch=armv8-a+crc+simd")
 #      else
 #        define ATTRIBUTES	_target_attribute("arch=armv8-a+crc")
 #      endif


### PR DESCRIPTION
"Reported" at
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1006139

Fixes: fc2ea22b4483 ("lib/arm: add ARM PMULL implementation of CRC-32")