### PR TITLE
scripts: remove obsolete file msc_test.bat

### DIFF
--- a/scripts/msc_test.bat
+++ b/scripts/msc_test.bat
@@ -1,3 +1,0 @@
-nmake /f Makefile.msc clean
-nmake /f Makefile.msc
-copy /y *.exe j:\exe\


### PR DESCRIPTION
This file has been unused since the switch to CMake.