### PR TITLE
lib/cpu_features: fix intrinsic support detection with latest clang

### DIFF
--- a/lib/arm/cpu_features.h
+++ b/lib/arm/cpu_features.h
@@ -98,7 +98,7 @@ static inline u32 get_arm_cpu_features(void) { return 0; }
 #if HAVE_PMULL_NATIVE || \
 	(HAVE_DYNAMIC_ARM_CPU_FEATURES && \
 	 HAVE_NEON_INTRIN /* needed to exclude soft float arm32 case */ && \
-	 (GCC_PREREQ(6, 1) || __has_builtin(__builtin_neon_vmull_p64) || \
+	 (GCC_PREREQ(6, 1) || CLANG_PREREQ(3, 5, 6010000) || \
 	  defined(_MSC_VER)) && \
 	  /*
 	   * On arm32 with clang, the crypto intrinsics (which include pmull)
@@ -179,7 +179,7 @@ static inline u32 get_arm_cpu_features(void) { return 0; }
 	!defined(__ARM_ARCH_7EM__)
 #      define HAVE_CRC32_INTRIN	1
 #    endif
-#  elif __has_builtin(__builtin_arm_crc32b)
+#  elif CLANG_PREREQ(3, 4, 6000000)
 #    define HAVE_CRC32_INTRIN	1
 #  elif defined(_MSC_VER)
 #    define HAVE_CRC32_INTRIN	1
@@ -202,7 +202,7 @@ static inline u32 get_arm_cpu_features(void) { return 0; }
 #  define HAVE_SHA3_INTRIN	(HAVE_NEON_INTRIN && \
 				 (HAVE_SHA3_NATIVE || HAVE_SHA3_TARGET) && \
 				 (GCC_PREREQ(9, 1) /* r268049 */ || \
-				  __has_builtin(__builtin_neon_veor3q_v)))
+				  CLANG_PREREQ(13, 0, 13160000)))
 #else
 #  define HAVE_SHA3_NATIVE	0
 #  define HAVE_SHA3_TARGET	0
@@ -218,7 +218,7 @@ static inline u32 get_arm_cpu_features(void) { return 0; }
 #  endif
 #  if HAVE_DOTPROD_NATIVE || \
 	(HAVE_DYNAMIC_ARM_CPU_FEATURES && \
-	 (GCC_PREREQ(8, 1) || __has_builtin(__builtin_neon_vdotq_v) || \
+	 (GCC_PREREQ(8, 1) || CLANG_PREREQ(7, 0, 10010000) || \
 	  defined(_MSC_VER)))
 #    define HAVE_DOTPROD_INTRIN	1
 #  else

--- a/lib/x86/cpu_features.h
+++ b/lib/x86/cpu_features.h
@@ -97,8 +97,7 @@ static inline u32 get_x86_cpu_features(void) { return 0; }
 #  define HAVE_PCLMUL_NATIVE	0
 #endif
 #if HAVE_PCLMUL_NATIVE || (HAVE_TARGET_INTRINSICS && \
-			   (GCC_PREREQ(4, 4) || \
-			    __has_builtin(__builtin_ia32_pclmulqdq128) || \
+			   (GCC_PREREQ(4, 4) || CLANG_PREREQ(3, 2, 0) || \
 			    defined(_MSC_VER)))
 #  define HAVE_PCLMUL_INTRIN	1
 #else
@@ -112,8 +111,7 @@ static inline u32 get_x86_cpu_features(void) { return 0; }
 #  define HAVE_AVX_NATIVE	0
 #endif
 #if HAVE_AVX_NATIVE || (HAVE_TARGET_INTRINSICS && \
-			(GCC_PREREQ(4, 6) || \
-			 __has_builtin(__builtin_ia32_maxps256) || \
+			(GCC_PREREQ(4, 6) || CLANG_PREREQ(3, 0, 0) || \
 			 defined(_MSC_VER)))
 #  define HAVE_AVX_INTRIN	1
 #else
@@ -127,8 +125,7 @@ static inline u32 get_x86_cpu_features(void) { return 0; }
 #  define HAVE_AVX2_NATIVE	0
 #endif
 #if HAVE_AVX2_NATIVE || (HAVE_TARGET_INTRINSICS && \
-			 (GCC_PREREQ(4, 7) || \
-			  __has_builtin(__builtin_ia32_psadbw256) || \
+			 (GCC_PREREQ(4, 7) || CLANG_PREREQ(3, 1, 0) || \
 			  defined(_MSC_VER)))
 #  define HAVE_AVX2_INTRIN	1
 #else
@@ -142,8 +139,7 @@ static inline u32 get_x86_cpu_features(void) { return 0; }
 #  define HAVE_BMI2_NATIVE	0
 #endif
 #if HAVE_BMI2_NATIVE || (HAVE_TARGET_INTRINSICS && \
-			 (GCC_PREREQ(4, 7) || \
-			  __has_builtin(__builtin_ia32_pdep_di) || \
+			 (GCC_PREREQ(4, 7) || CLANG_PREREQ(3, 1, 0) || \
 			  defined(_MSC_VER)))
 #  define HAVE_BMI2_INTRIN	1
 #else


### PR DESCRIPTION
Unfortunately, checks like __has_builtin(__builtin_ia32_pclmulqdq128) have stopped working properly with clang, starting with clang 15 on x86_64 and clang 16 on arm64.  They now only expand to '1' when the corresponding CPU feature is enabled on the command line.  As a result, a lot of optimized code (mainly for the checksums) is not used.

The reason that libdeflate is doing these checks in the first place is just to exclude old compiler versions that don't support the corresponding set of intrinsics.  So, let's do it the "bad" way and instead check the clang version number directly...