### PR TITLE
Add allocate / free routines using passed in custom functions

### DIFF
--- a/lib/deflate_compress.c
+++ b/lib/deflate_compress.c
@@ -3809,6 +3809,13 @@ deflate_init_offset_slot_full(struct libdeflate_compressor *c)
 LIBDEFLATEAPI struct libdeflate_compressor *
 libdeflate_alloc_compressor(int compression_level)
 {
+	return libdeflate_alloc_compressor_custom(compression_level, libdeflate_malloc);
+}
+
+LIBDEFLATEAPI struct libdeflate_compressor *
+libdeflate_alloc_compressor_custom(int compression_level,
+					   void *(*alloc_func)(size_t))
+{
 	struct libdeflate_compressor *c;
 	size_t size = offsetof(struct libdeflate_compressor, p);
 
@@ -3829,7 +3836,7 @@ libdeflate_alloc_compressor(int compression_level)
 			size += sizeof(c->p.f);
 	}
 
-	c = libdeflate_aligned_malloc(MATCHFINDER_MEM_ALIGNMENT, size);
+	c = libdeflate_aligned_malloc(alloc_func, MATCHFINDER_MEM_ALIGNMENT, size);
 	if (!c)
 		return NULL;
 
@@ -3977,7 +3984,14 @@ libdeflate_deflate_compress(struct libdeflate_compressor *c,
 LIBDEFLATEAPI void
 libdeflate_free_compressor(struct libdeflate_compressor *c)
 {
-	libdeflate_aligned_free(c);
+	libdeflate_aligned_free(libdeflate_free, c);
+}
+
+LIBDEFLATEAPI void
+libdeflate_free_compressor_custom(struct libdeflate_compressor *c,
+					  void (*free_func)(void *))
+{
+	libdeflate_aligned_free(free_func, c);
 }
 
 unsigned int

--- a/lib/deflate_decompress.c
+++ b/lib/deflate_decompress.c
@@ -1142,6 +1142,12 @@ libdeflate_deflate_decompress(struct libdeflate_decompressor *d,
 LIBDEFLATEAPI struct libdeflate_decompressor *
 libdeflate_alloc_decompressor(void)
 {
+	return libdeflate_alloc_decompressor_custom(libdeflate_malloc);
+}
+
+LIBDEFLATEAPI struct libdeflate_decompressor *
+libdeflate_alloc_decompressor_custom(void *(malloc_func)(size_t))
+{
 	/*
 	 * Note that only certain parts of the decompressor actually must be
 	 * initialized here:
@@ -1157,7 +1163,7 @@ libdeflate_alloc_decompressor(void)
 	 *
 	 * But for simplicity, we currently just zero the whole decompressor.
 	 */
-	struct libdeflate_decompressor *d = libdeflate_malloc(sizeof(*d));
+	struct libdeflate_decompressor *d = malloc_func(sizeof(*d));
 
 	if (d == NULL)
 		return NULL;
@@ -1169,4 +1175,11 @@ LIBDEFLATEAPI void
 libdeflate_free_decompressor(struct libdeflate_decompressor *d)
 {
 	libdeflate_free(d);
+}
+
+LIBDEFLATEAPI void
+libdeflate_free_decompressor_custom(struct libdeflate_decompressor *d,
+						void (*free_func)(void *))
+{
+	free_func(d);
 }

--- a/lib/lib_common.h
+++ b/lib/lib_common.h
@@ -42,8 +42,9 @@
 void *libdeflate_malloc(size_t size);
 void libdeflate_free(void *ptr);
 
-void *libdeflate_aligned_malloc(size_t alignment, size_t size);
-void libdeflate_aligned_free(void *ptr);
+void *libdeflate_aligned_malloc(void *(*malloc_func)(size_t),
+                           size_t alignment, size_t size);
+void libdeflate_aligned_free(void (*free_func)(void *), void *ptr);
 
 #ifdef FREESTANDING
 /*

--- a/lib/utils.c
+++ b/lib/utils.c
@@ -50,9 +50,10 @@ libdeflate_free(void *ptr)
 }
 
 void *
-libdeflate_aligned_malloc(size_t alignment, size_t size)
+libdeflate_aligned_malloc(void *(*malloc_func)(size_t),
+			  size_t alignment, size_t size)
 {
-	void *ptr = libdeflate_malloc(sizeof(void *) + alignment - 1 + size);
+	void *ptr = malloc_func(sizeof(void *) + alignment - 1 + size);
 	if (ptr) {
 		void *orig_ptr = ptr;
 		ptr = (void *)ALIGN((uintptr_t)ptr + sizeof(void *), alignment);
@@ -62,10 +63,10 @@ libdeflate_aligned_malloc(size_t alignment, size_t size)
 }
 
 void
-libdeflate_aligned_free(void *ptr)
+libdeflate_aligned_free(void (*free_func)(void *), void *ptr)
 {
 	if (ptr)
-		libdeflate_free(((void **)ptr)[-1]);
+		free_func(((void **)ptr)[-1]);
 }
 
 LIBDEFLATEAPI void

--- a/libdeflate.h
+++ b/libdeflate.h
@@ -58,6 +58,20 @@ LIBDEFLATEAPI struct libdeflate_compressor *
 libdeflate_alloc_compressor(int compression_level);
 
 /*
+ * libdeflate_alloc_compressor_custom() allocates a new compressor
+ * using the provided custom allocator. This enables use of the
+ * library in contexts where changing the global allocator may change
+ * results for other threads using libdeflate concurrently.
+ *
+ * Otherwise, it behaves the same as libdeflate_alloc_compressor. See
+ * the description of that function to understand the treatment of the
+ * compression_level and return values.
+ */
+LIBDEFLATEAPI struct libdeflate_compressor *
+libdeflate_alloc_compressor_custom(int compression_level,
+					   void *(*malloc_func)(size_t));
+
+/*
  * libdeflate_deflate_compress() performs raw DEFLATE compression on a buffer of
  * data.  It attempts to compress 'in_nbytes' bytes of data located at 'in' and
  * write the result to 'out', which has space for 'out_nbytes_avail' bytes.  The
@@ -166,6 +180,16 @@ libdeflate_gzip_compress_bound(struct libdeflate_compressor *compressor,
 LIBDEFLATEAPI void
 libdeflate_free_compressor(struct libdeflate_compressor *compressor);
 
+/*
+ * libdeflate_free_compressor_custom() frees a compressor that was
+ * allocated with libdeflate_alloc_compressor_custom(). If a NULL
+ * pointer is passed in, no action is taken.
+ */
+LIBDEFLATEAPI void
+libdeflate_free_compressor_custom(struct libdeflate_compressor *compressor,
+							  void (*free_func)(void *));
+
+
 /* ========================================================================== */
 /*                             Decompression                                  */
 /* ========================================================================== */
@@ -186,6 +210,19 @@ struct libdeflate_decompressor;
  */
 LIBDEFLATEAPI struct libdeflate_decompressor *
 libdeflate_alloc_decompressor(void);
+
+/*
+ * libdeflate_alloc_decompressor_custom() allocates a new decompressor
+ * using the provided custom allocator. This enables use of the
+ * library in contexts where changing the global allocator may change
+ * results for other threads using libdeflate concurrently.
+ *
+ * Otherwise, it behaves the same as
+ * libdeflate_alloc_decompressor(). See the description of that
+ * function to understand the behavior and return values.
+ */
+LIBDEFLATEAPI struct libdeflate_decompressor *
+libdeflate_alloc_decompressor_custom(void *(*malloc_func)(size_t));
 
 /*
  * Result of a call to libdeflate_deflate_decompress(),
@@ -321,6 +358,16 @@ libdeflate_gzip_decompress_ex(struct libdeflate_decompressor *decompressor,
  */
 LIBDEFLATEAPI void
 libdeflate_free_decompressor(struct libdeflate_decompressor *decompressor);
+
+/*
+ * libdeflate_free_decompressor_custom() frees a decompressor
+ * that was allocated with
+ * libdeflate_alloc_decompressor_custom(). If a NULL pointer is
+ * passed in, no action is taken.
+ */
+LIBDEFLATEAPI void
+libdeflate_free_decompressor_custom(struct libdeflate_decompressor *decompressor,
+							  void (*free_func)(void *));
 
 /* ========================================================================== */
 /*                                Checksums                                   */

--- a/programs/test_custom_malloc.c
+++ b/programs/test_custom_malloc.c
@@ -81,5 +81,29 @@ tmain(int argc, tchar *argv[])
 	ASSERT(malloc_count == 1);
 	ASSERT(free_count == 0);
 
+	/* Further, test allocations without global function pointers. */
+
+	libdeflate_set_memory_allocator(NULL, NULL);
+
+	for (level = 0; level <= 12; level++) {
+		malloc_count = free_count = 0;
+		c = libdeflate_alloc_compressor_custom(level, do_malloc);
+		ASSERT(c != NULL);
+		ASSERT(malloc_count == 1);
+		ASSERT(free_count == 0);
+		libdeflate_free_compressor_custom(c, do_free);
+		ASSERT(malloc_count == 1);
+		ASSERT(free_count == 1);
+	}
+
+	malloc_count = free_count = 0;
+	d = libdeflate_alloc_decompressor_custom(do_malloc);
+	ASSERT(d != NULL);
+	ASSERT(malloc_count == 1);
+	ASSERT(free_count == 0);
+	libdeflate_free_decompressor_custom(d, do_free);
+	ASSERT(malloc_count == 1);
+	ASSERT(free_count == 1);
+
 	return 0;
 }


### PR DESCRIPTION
In some environments, it may not be safe to globally change the allocator, if another thread is concurrently using libdeflate with a different allocator. As such, provide a path where the allocator and free functions can be provided with the routines instead of changing the global pointer.