### PR TITLE
CMake: Test policy existence directly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 
 # With MSVC, don't automatically append /W3 to the compiler flags.
 # This makes it possible for the user to select /W4.
-if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.15")
+if(POLICY CMP0092)
     cmake_policy(SET CMP0092 NEW)
 endif()
 


### PR DESCRIPTION
While it's possible to limit policy-change commands based on the CMake version(s) where they exist, that's not entirely future-proof. (Some very old policies may someday be removed from later releases.) It's also not necessary, as the most robust (and [recommended](https://cmake.org/cmake/help/v3.27/manual/cmake-policies.7.html#introduction)) approach is to simply test for the existence of the policy _itself_, using `if(POLICY ...)`.