### PR TITLE
ARM CPU feature cleanups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y clang llvm libz-dev valgrind
+    - run: sudo sysctl kernel.randomize_va_space=0 # https://bugs.launchpad.net/ubuntu/+source/llvm-toolchain-14/+bug/2048768
     - run: scripts/run_tests.sh
     - name: Direct compilation without official build system
       run: $CC -O2 -Wall -Werror lib/*{,/*}.c programs/{gzip,prog_util,tgetopt}.c -o libdeflate-gzip
@@ -287,5 +288,6 @@ jobs:
         sudo apt-get install -y clang llvm
     - name: Fuzz
       run: |
+        sudo sysctl kernel.randomize_va_space=0 # https://bugs.launchpad.net/ubuntu/+source/llvm-toolchain-14/+bug/2048768
         scripts/libFuzzer/fuzz.sh --time=120 ${{matrix.sanitizer}} \
             ${{matrix.target}}

--- a/lib/arm/adler32_impl.h
+++ b/lib/arm/adler32_impl.h
@@ -46,7 +46,6 @@
 #  else
 #    define ATTRIBUTES	_target_attribute("+simd")
 #  endif
-#  include <arm_neon.h>
 static ATTRIBUTES MAYBE_UNUSED u32
 adler32_arm_neon(u32 adler, const u8 *p, size_t len)
 {
@@ -224,7 +223,6 @@ adler32_arm_neon(u32 adler, const u8 *p, size_t len)
 #  else
 #    define ATTRIBUTES	_target_attribute("arch=armv8.2-a+dotprod")
 #  endif
-#  include <arm_neon.h>
 static ATTRIBUTES u32
 adler32_arm_neon_dotprod(u32 adler, const u8 *p, size_t len)
 {

--- a/lib/arm/adler32_impl.h
+++ b/lib/arm/adler32_impl.h
@@ -332,7 +332,7 @@ adler32_arm_neon_dotprod(u32 adler, const u8 *p, size_t len)
 #undef ATTRIBUTES
 #endif /* NEON+dotprod implementation */
 
-#if defined(adler32_arm_neon_dotprod) && HAVE_DOTPROD_NATIVE
+#if defined(adler32_arm_neon_dotprod) && defined(__ARM_FEATURE_DOTPROD)
 #define DEFAULT_IMPL	adler32_arm_neon_dotprod
 #else
 static inline adler32_func_t

--- a/lib/arm/cpu_features.c
+++ b/lib/arm/cpu_features.c
@@ -113,10 +113,6 @@ static u32 query_arm_cpu_features(void)
 	STATIC_ASSERT(sizeof(long) == 4);
 	if (hwcap & (1 << 12))	/* HWCAP_NEON */
 		features |= ARM_CPU_FEATURE_NEON;
-	if (hwcap2 & (1 << 1))	/* HWCAP2_PMULL */
-		features |= ARM_CPU_FEATURE_PMULL;
-	if (hwcap2 & (1 << 4))	/* HWCAP2_CRC32 */
-		features |= ARM_CPU_FEATURE_CRC32;
 #else
 	STATIC_ASSERT(sizeof(long) == 8);
 	if (hwcap & (1 << 1))	/* HWCAP_ASIMD */

--- a/lib/arm/cpu_features.h
+++ b/lib/arm/cpu_features.h
@@ -78,7 +78,7 @@ static inline u32 get_arm_cpu_features(void) { return 0; }
 #endif /* !HAVE_DYNAMIC_ARM_CPU_FEATURES */
 
 /* NEON */
-#if defined(__ARM_NEON) || defined(ARCH_ARM64)
+#if defined(__ARM_NEON) || (defined(_MSC_VER) && defined(ARCH_ARM64))
 #  define HAVE_NEON_NATIVE	1
 #else
 #  define HAVE_NEON_NATIVE	0

--- a/lib/arm/cpu_features.h
+++ b/lib/arm/cpu_features.h
@@ -45,9 +45,15 @@
 
 #define ARM_CPU_FEATURE_NEON		(1 << 0)
 #define ARM_CPU_FEATURE_PMULL		(1 << 1)
-#define ARM_CPU_FEATURE_CRC32		(1 << 2)
-#define ARM_CPU_FEATURE_SHA3		(1 << 3)
-#define ARM_CPU_FEATURE_DOTPROD		(1 << 4)
+/*
+ * PREFER_PMULL indicates that the CPU has very high pmull throughput, and so
+ * the 12x wide pmull-based CRC-32 implementation is likely to be faster than an
+ * implementation based on the crc32 instructions.
+ */
+#define ARM_CPU_FEATURE_PREFER_PMULL	(1 << 2)
+#define ARM_CPU_FEATURE_CRC32		(1 << 3)
+#define ARM_CPU_FEATURE_SHA3		(1 << 4)
+#define ARM_CPU_FEATURE_DOTPROD		(1 << 5)
 
 #define HAVE_NEON(features)	(HAVE_NEON_NATIVE    || ((features) & ARM_CPU_FEATURE_NEON))
 #define HAVE_PMULL(features)	(HAVE_PMULL_NATIVE   || ((features) & ARM_CPU_FEATURE_PMULL))

--- a/lib/arm/cpu_features.h
+++ b/lib/arm/cpu_features.h
@@ -115,29 +115,6 @@ static inline u32 get_arm_cpu_features(void) { return 0; }
 #else
 #  define HAVE_PMULL_INTRIN	0
 #endif
-/*
- * Set USE_PMULL_TARGET_EVEN_IF_NATIVE if a workaround for a gcc bug that was
- * fixed by commit 11a113d501ff ("aarch64: Simplify feature definitions") in gcc
- * 13 is needed.  A minimal program that fails to build due to this bug when
- * compiled with -mcpu=emag, at least with gcc 10 through 12, is:
- *
- *    static inline __attribute__((always_inline,target("+crypto"))) void f() {}
- *    void g() { f(); }
- *
- * The error is:
- *
- *    error: inlining failed in call to ‘always_inline’ ‘f’: target specific option mismatch
- *
- * The workaround is to explicitly add the crypto target to the non-inline
- * function g(), even though this should not be required due to -mcpu=emag
- * enabling 'crypto' natively and causing __ARM_FEATURE_CRYPTO to be defined.
- */
-#if HAVE_PMULL_NATIVE && defined(ARCH_ARM64) && \
-		GCC_PREREQ(6, 1) && !GCC_PREREQ(13, 1)
-#  define USE_PMULL_TARGET_EVEN_IF_NATIVE	1
-#else
-#  define USE_PMULL_TARGET_EVEN_IF_NATIVE	0
-#endif
 
 /* CRC32 */
 #ifdef __ARM_FEATURE_CRC32

--- a/lib/arm/cpu_features.h
+++ b/lib/arm/cpu_features.h
@@ -55,12 +55,6 @@
 #define ARM_CPU_FEATURE_SHA3		(1 << 4)
 #define ARM_CPU_FEATURE_DOTPROD		(1 << 5)
 
-#define HAVE_NEON(features)	(HAVE_NEON_NATIVE    || ((features) & ARM_CPU_FEATURE_NEON))
-#define HAVE_PMULL(features)	(HAVE_PMULL_NATIVE   || ((features) & ARM_CPU_FEATURE_PMULL))
-#define HAVE_CRC32(features)	(HAVE_CRC32_NATIVE   || ((features) & ARM_CPU_FEATURE_CRC32))
-#define HAVE_SHA3(features)	(HAVE_SHA3_NATIVE    || ((features) & ARM_CPU_FEATURE_SHA3))
-#define HAVE_DOTPROD(features)	(HAVE_DOTPROD_NATIVE || ((features) & ARM_CPU_FEATURE_DOTPROD))
-
 #if HAVE_DYNAMIC_ARM_CPU_FEATURES
 #define ARM_CPU_FEATURES_KNOWN		(1U << 31)
 extern volatile u32 libdeflate_arm_cpu_features;
@@ -79,8 +73,10 @@ static inline u32 get_arm_cpu_features(void) { return 0; }
 
 /* NEON */
 #if defined(__ARM_NEON) || (defined(_MSC_VER) && defined(ARCH_ARM64))
+#  define HAVE_NEON(features)	1
 #  define HAVE_NEON_NATIVE	1
 #else
+#  define HAVE_NEON(features)	((features) & ARM_CPU_FEATURE_NEON)
 #  define HAVE_NEON_NATIVE	0
 #endif
 /*
@@ -98,9 +94,9 @@ static inline u32 get_arm_cpu_features(void) { return 0; }
 
 /* PMULL */
 #ifdef __ARM_FEATURE_CRYPTO
-#  define HAVE_PMULL_NATIVE	1
+#  define HAVE_PMULL(features)	1
 #else
-#  define HAVE_PMULL_NATIVE	0
+#  define HAVE_PMULL(features)	((features) & ARM_CPU_FEATURE_PMULL)
 #endif
 #if defined(ARCH_ARM64) && HAVE_NEON_INTRIN && \
 	(GCC_PREREQ(6, 1) || defined(__clang__) || defined(_MSC_VER)) && \
@@ -118,9 +114,9 @@ static inline u32 get_arm_cpu_features(void) { return 0; }
 
 /* CRC32 */
 #ifdef __ARM_FEATURE_CRC32
-#  define HAVE_CRC32_NATIVE	1
+#  define HAVE_CRC32(features)	1
 #else
-#  define HAVE_CRC32_NATIVE	0
+#  define HAVE_CRC32(features)	((features) & ARM_CPU_FEATURE_CRC32)
 #endif
 #if defined(ARCH_ARM64) && \
 	(defined(__GNUC__) || defined(__clang__) || defined(_MSC_VER))
@@ -166,9 +162,9 @@ static inline u32 get_arm_cpu_features(void) { return 0; }
 
 /* SHA3 (needed for the eor3 instruction) */
 #ifdef __ARM_FEATURE_SHA3
-#  define HAVE_SHA3_NATIVE	1
+#  define HAVE_SHA3(features)	1
 #else
-#  define HAVE_SHA3_NATIVE	0
+#  define HAVE_SHA3(features)	((features) & ARM_CPU_FEATURE_SHA3)
 #endif
 #if defined(ARCH_ARM64) && HAVE_NEON_INTRIN && \
 	(GCC_PREREQ(9, 1) /* r268049 */ || \
@@ -194,9 +190,9 @@ static inline u32 get_arm_cpu_features(void) { return 0; }
 
 /* dotprod */
 #ifdef __ARM_FEATURE_DOTPROD
-#  define HAVE_DOTPROD_NATIVE	1
+#  define HAVE_DOTPROD(features)	1
 #else
-#  define HAVE_DOTPROD_NATIVE	0
+#  define HAVE_DOTPROD(features)	((features) & ARM_CPU_FEATURE_DOTPROD)
 #endif
 #if defined(ARCH_ARM64) && HAVE_NEON_INTRIN && \
 	(GCC_PREREQ(8, 1) || CLANG_PREREQ(7, 0, 10010000) || defined(_MSC_VER))

--- a/lib/arm/cpu_features.h
+++ b/lib/arm/cpu_features.h
@@ -185,16 +185,21 @@ static inline u32 get_arm_cpu_features(void) { return 0; }
 #if HAVE_DOTPROD_INTRIN && !HAVE_DOTPROD_NATIVE && defined(__clang__)
 #  define __ARM_FEATURE_DOTPROD	1
 #endif
-#if HAVE_CRC32_INTRIN && !HAVE_CRC32_NATIVE && defined(__clang__)
+
+#if HAVE_CRC32_INTRIN && (defined(__GNUC__) || defined(__clang__))
 #  include <arm_acle.h>
+#endif
+#if HAVE_NEON_INTRIN
+#  include <arm_neon.h>
+#endif
+
+#if HAVE_CRC32_INTRIN && !HAVE_CRC32_NATIVE && defined(__clang__)
 #  undef __ARM_FEATURE_CRC32
 #endif
 #if HAVE_SHA3_INTRIN && !HAVE_SHA3_NATIVE && defined(__clang__)
-#  include <arm_neon.h>
 #  undef __ARM_FEATURE_SHA3
 #endif
 #if HAVE_DOTPROD_INTRIN && !HAVE_DOTPROD_NATIVE && defined(__clang__)
-#  include <arm_neon.h>
 #  undef __ARM_FEATURE_DOTPROD
 #endif
 

--- a/lib/arm/cpu_features.h
+++ b/lib/arm/cpu_features.h
@@ -101,17 +101,10 @@ static inline u32 get_arm_cpu_features(void) { return 0; }
 #else
 #  define HAVE_PMULL_NATIVE	0
 #endif
-#if HAVE_PMULL_NATIVE || \
-	(HAVE_DYNAMIC_ARM_CPU_FEATURES && \
-	 HAVE_NEON_INTRIN /* needed to exclude soft float arm32 case */ && \
-	 (GCC_PREREQ(6, 1) || defined(__clang__) || defined(_MSC_VER)) && \
-	  /*
-	   * On arm32 with clang, the crypto intrinsics (which include pmull)
-	   * are not defined, even when using -mfpu=crypto-neon-fp-armv8,
-	   * because clang's <arm_neon.h> puts their definitions behind
-	   * __aarch64__.
-	   */ \
-	 !(defined(ARCH_ARM32) && defined(__clang__)))
+#if defined(ARCH_ARM64) && \
+	(HAVE_PMULL_NATIVE || \
+	 (HAVE_DYNAMIC_ARM_CPU_FEATURES && \
+	  (GCC_PREREQ(6, 1) || defined(__clang__) || defined(_MSC_VER))))
 #  define HAVE_PMULL_INTRIN	CPU_IS_LITTLE_ENDIAN() /* untested on big endian */
    /* Work around MSVC's vmull_p64() taking poly64x1_t instead of poly64_t */
 #  ifdef _MSC_VER
@@ -152,43 +145,10 @@ static inline u32 get_arm_cpu_features(void) { return 0; }
 #else
 #  define HAVE_CRC32_NATIVE	0
 #endif
-#undef HAVE_CRC32_INTRIN
-#if HAVE_CRC32_NATIVE
+#if defined(ARCH_ARM64) && (HAVE_CRC32_NATIVE || defined(__GNUC__) || \
+			    defined(__clang__) || defined(_MSC_VER))
 #  define HAVE_CRC32_INTRIN	1
-#elif HAVE_DYNAMIC_ARM_CPU_FEATURES
-#  if GCC_PREREQ(1, 0)
-    /*
-     * Support for ARM CRC32 intrinsics when CRC32 instructions are not enabled
-     * in the main target has been affected by two gcc bugs, which we must avoid
-     * by only allowing gcc versions that have the corresponding fixes.  First,
-     * gcc commit 943766d37ae4 ("[arm] Fix use of CRC32 intrinsics with Armv8-a
-     * and hard-float"), i.e. gcc 8.4+, 9.3+, 10.1+, or 11+, is needed.  Second,
-     * gcc commit c1cdabe3aab8 ("arm: reorder assembler architecture directives
-     * [PR101723]"), i.e. gcc 9.5+, 10.4+, 11.3+, or 12+, is needed when
-     * binutils is 2.34 or later, due to
-     * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=104439.  We use the second
-     * set of prerequisites, as they are stricter and we have no way to detect
-     * the binutils version directly from a C source file.
-     *
-     * Also exclude the cases where the main target arch is armv6kz or armv7e-m.
-     * In those cases, gcc doesn't let functions that use the main arch be
-     * inlined into functions that are targeted to armv8-a+crc.  (armv8-a is
-     * necessary for crc to be accepted at all.)  That causes build errors.
-     * This issue happens for these specific sub-archs because they are not a
-     * subset of armv8-a.  Note: clang does not have this limitation.
-     */
-#    if (GCC_PREREQ(11, 3) || \
-	 (GCC_PREREQ(10, 4) && !GCC_PREREQ(11, 0)) || \
-	 (GCC_PREREQ(9, 5) && !GCC_PREREQ(10, 0))) && \
-	!defined(__ARM_ARCH_6KZ__) && \
-	!defined(__ARM_ARCH_7EM__)
-#      define HAVE_CRC32_INTRIN	1
-#    endif
-#  elif defined(__clang__) || defined(_MSC_VER)
-#    define HAVE_CRC32_INTRIN	1
-#  endif
-#endif
-#ifndef HAVE_CRC32_INTRIN
+#else
 #  define HAVE_CRC32_INTRIN	0
 #endif
 
@@ -239,8 +199,7 @@ static inline u32 get_arm_cpu_features(void) { return 0; }
  * defined, though, so work around this by temporarily defining the
  * corresponding __ARM_FEATURE_* macros while including the headers.
  */
-#if HAVE_CRC32_INTRIN && !HAVE_CRC32_NATIVE && \
-	(defined(__clang__) || defined(ARCH_ARM32))
+#if HAVE_CRC32_INTRIN && !HAVE_CRC32_NATIVE && defined(__clang__)
 #  define __ARM_FEATURE_CRC32	1
 #endif
 #if HAVE_SHA3_INTRIN && !HAVE_SHA3_NATIVE && defined(__clang__)
@@ -249,8 +208,7 @@ static inline u32 get_arm_cpu_features(void) { return 0; }
 #if HAVE_DOTPROD_INTRIN && !HAVE_DOTPROD_NATIVE && defined(__clang__)
 #  define __ARM_FEATURE_DOTPROD	1
 #endif
-#if HAVE_CRC32_INTRIN && !HAVE_CRC32_NATIVE && \
-	(defined(__clang__) || defined(ARCH_ARM32))
+#if HAVE_CRC32_INTRIN && !HAVE_CRC32_NATIVE && defined(__clang__)
 #  include <arm_acle.h>
 #  undef __ARM_FEATURE_CRC32
 #endif

--- a/lib/arm/crc32_impl.h
+++ b/lib/arm/crc32_impl.h
@@ -51,10 +51,6 @@
 #    define ATTRIBUTES	_target_attribute("+crc")
 #  endif
 
-#ifndef _MSC_VER
-#  include <arm_acle.h>
-#endif
-
 /*
  * Combine the CRCs for 4 adjacent chunks of length L = CRC32_FIXED_CHUNK_LEN
  * bytes each by computing:
@@ -229,11 +225,6 @@ crc32_arm_crc(u32 crc, const u8 *p, size_t len)
 #  else
 #    define ATTRIBUTES	_target_attribute("+crc,+crypto")
 #  endif
-
-#ifndef _MSC_VER
-#  include <arm_acle.h>
-#endif
-#include <arm_neon.h>
 
 /* Do carryless multiplication of two 32-bit values. */
 static forceinline ATTRIBUTES u64

--- a/lib/arm/crc32_impl.h
+++ b/lib/arm/crc32_impl.h
@@ -544,11 +544,8 @@ crc32_arm_pmullx4(u32 crc, const u8 *p, size_t len)
  *
  * This like crc32_arm_pmullx12_crc(), but it adds the eor3 instruction (from
  * the sha3 extension) for even better performance.
- *
- * Note: we require HAVE_SHA3_TARGET rather than HAVE_SHA3_INTRIN, as we have an
- * inline asm fallback for eor3.
  */
-#if HAVE_PMULL_INTRIN && HAVE_CRC32_INTRIN && HAVE_SHA3_TARGET
+#if HAVE_PMULL_INTRIN && HAVE_CRC32_INTRIN && HAVE_SHA3_INTRIN
 #  define crc32_arm_pmullx12_crc_eor3	crc32_arm_pmullx12_crc_eor3
 #  define SUFFIX				 _pmullx12_crc_eor3
 #  ifdef __clang__

--- a/lib/arm/crc32_pmull_helpers.h
+++ b/lib/arm/crc32_pmull_helpers.h
@@ -91,18 +91,10 @@ static forceinline ATTRIBUTES uint8x16_t
 ADD_SUFFIX(eor3)(uint8x16_t a, uint8x16_t b, uint8x16_t c)
 {
 #if ENABLE_EOR3
-#if HAVE_SHA3_INTRIN
 	return veor3q_u8(a, b, c);
 #else
-	uint8x16_t res;
-
-	__asm__("eor3 %0.16b, %1.16b, %2.16b, %3.16b"
-		: "=w" (res) : "w" (a), "w" (b), "w" (c));
-	return res;
-#endif
-#else /* ENABLE_EOR3 */
 	return veorq_u8(veorq_u8(a, b), c);
-#endif /* !ENABLE_EOR3 */
+#endif
 }
 #define eor3	ADD_SUFFIX(eor3)
 

--- a/lib/arm/crc32_pmull_helpers.h
+++ b/lib/arm/crc32_pmull_helpers.h
@@ -37,8 +37,6 @@
  *	Use the eor3 instruction (from the sha3 extension).
  */
 
-#include <arm_neon.h>
-
 /* Create a vector with 'a' in the first 4 bytes, and the rest zeroed out. */
 #undef u32_to_bytevec
 static forceinline ATTRIBUTES uint8x16_t

--- a/lib/arm/crc32_pmull_wide.h
+++ b/lib/arm/crc32_pmull_wide.h
@@ -45,11 +45,6 @@
  * Apple M1 processor is an example of such a CPU.
  */
 
-#ifndef _MSC_VER
-#  include <arm_acle.h>
-#endif
-#include <arm_neon.h>
-
 #include "crc32_pmull_helpers.h"
 
 static ATTRIBUTES u32

--- a/lib/arm/crc32_pmull_wide.h
+++ b/lib/arm/crc32_pmull_wide.h
@@ -52,7 +52,7 @@
 
 #include "crc32_pmull_helpers.h"
 
-static ATTRIBUTES MAYBE_UNUSED u32
+static ATTRIBUTES u32
 ADD_SUFFIX(crc32_arm)(u32 crc, const u8 *p, size_t len)
 {
 	uint8x16_t v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11;

--- a/lib/arm/matchfinder_impl.h
+++ b/lib/arm/matchfinder_impl.h
@@ -31,7 +31,6 @@
 #include "cpu_features.h"
 
 #if HAVE_NEON_NATIVE
-#  include <arm_neon.h>
 static forceinline void
 matchfinder_init_neon(mf_pos_t *data, size_t size)
 {

--- a/scripts/checksum_benchmarks.sh
+++ b/scripts/checksum_benchmarks.sh
@@ -173,14 +173,24 @@ i386|x86_64)
 		disable_cpu_feature pclmulqdq "-mno-pclmul"
 	fi
 	;;
-arm*|aarch*)
+aarch*)
+	EXTRA_CFLAGS=("-march=armv8-a")
+	if have_cpu_features pmull crc32 sha3; then
+		do_benchmark "pmullx12_crc_eor3"
+		disable_cpu_feature sha3
+	fi
+	if have_cpu_features pmull crc32; then
+		do_benchmark "pmullx12_crc"
+		disable_cpu_feature prefer_pmull
+		do_benchmark "crc_pmullcombine"
+	fi
 	if have_cpu_features crc32; then
-		do_benchmark "ARM"
-		disable_cpu_feature crc32 "-march=armv8-a+nocrc"
+		do_benchmark "crc"
+		disable_cpu_feature crc32
 	fi
 	if have_cpu_features pmull; then
-		do_benchmark "PMULL"
-		disable_cpu_feature pmull "-march=armv8-a+nocrc+nocrypto"
+		do_benchmark "pmull4x"
+		disable_cpu_feature pmull
 	fi
 	;;
 esac

--- a/scripts/checksum_benchmarks.sh
+++ b/scripts/checksum_benchmarks.sh
@@ -226,9 +226,15 @@ arm*)
 	fi
 	;;
 aarch*)
+	EXTRA_CFLAGS=("-march=armv8-a")
+	if have_cpu_features asimd asimddp; then
+		do_benchmark "DOTPROD"
+		disable_cpu_feature dotprod
+	fi
 	if have_cpu_features asimd; then
 		do_benchmark "NEON"
-		disable_cpu_feature neon "-march=armv8-a+nosimd"
+		disable_cpu_feature neon
+		EXTRA_CFLAGS=("-march=armv8-a+nosimd")
 	fi
 	;;
 esac

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -146,7 +146,7 @@ build_and_run_tests()
 				   avx2 avx bmi2 pclmulqdq sse2)
 			;;
 		arm*|aarch*)
-			features+=(dotprod sha3 crc32 pmull neon)
+			features+=(dotprod sha3 prefer_pmull crc32 pmull neon)
 			;;
 		esac
 	fi


### PR DESCRIPTION
* checksum_benchmarks.sh: handle adler32_arm_neon_dotprod()
* lib/arm: move selection of pmull_wide into arm_cpu_features
* lib/arm: drop the arm32 support for pmull and crc32 instructions
* lib/arm: simplify by not trying to skip target attributes
* lib/arm: fix arm64 builds with -march=armv8-a+nosimd
* lib/arm: centralize the intrinsic header inclusions
* lib/arm: simplify conditions for detecting intrinsics
* lib/arm: use asm fallback when clang intrinsics unusable
* lib/arm: remove unnecessary NATIVE macros
