### PR TITLE
lib/x86: finish removal of a workaround for very old gcc versions

### DIFF
--- a/lib/x86/cpu_features.c
+++ b/lib/x86/cpu_features.c
@@ -44,10 +44,7 @@ cpuid(u32 leaf, u32 subleaf, u32 *a, u32 *b, u32 *c, u32 *d)
 	*c = result[2];
 	*d = result[3];
 #else
-	__asm__ volatile(".ifnc %%ebx, %1; mov  %%ebx, %1; .endif\n"
-			 "cpuid                                  \n"
-			 ".ifnc %%ebx, %1; xchg %%ebx, %1; .endif\n"
-			 : "=a" (*a), "=b" (*b), "=c" (*c), "=d" (*d)
+	__asm__ volatile("cpuid" : "=a" (*a), "=b" (*b), "=c" (*c), "=d" (*d)
 			 : "a" (leaf), "c" (subleaf));
 #endif
 }


### PR DESCRIPTION
Remove some code that should have been removed in commit 44a6510c0d94 ("lib/x86: remove a workaround for very old gcc versions").