### PR TITLE
lib/arm: don't use explicit armv8.2-a on gcc 13.2 and later

### DIFF
--- a/lib/arm/adler32_impl.h
+++ b/lib/arm/adler32_impl.h
@@ -214,11 +214,13 @@ adler32_arm_neon(u32 adler, const u8 *p, size_t len)
 #  ifdef __clang__
 #    define ATTRIBUTES	_target_attribute("dotprod")
    /*
-    * With gcc, arch=armv8.2-a is needed for dotprod intrinsics, unless the
-    * default target is armv8.3-a or later in which case it must be omitted.
-    * armv8.3-a or later can be detected by checking for __ARM_FEATURE_JCVT.
+    * With gcc 13.1 and earlier (before gcc commit 73d3bc348190 or 9aac37ab8a7b,
+    * "aarch64: Remove architecture dependencies from intrinsics"),
+    * arch=armv8.2-a is needed for the dotprod intrinsics, unless the default
+    * target is armv8.3-a or later in which case it must be omitted.  armv8.3-a
+    * or later can be detected by checking for __ARM_FEATURE_JCVT.
     */
-#  elif defined(__ARM_FEATURE_JCVT)
+#  elif GCC_PREREQ(13, 2) || defined(__ARM_FEATURE_JCVT)
 #    define ATTRIBUTES	_target_attribute("+dotprod")
 #  else
 #    define ATTRIBUTES	_target_attribute("arch=armv8.2-a+dotprod")

--- a/lib/arm/crc32_impl.h
+++ b/lib/arm/crc32_impl.h
@@ -551,11 +551,13 @@ crc32_arm_pmullx4(u32 crc, const u8 *p, size_t len)
 #  ifdef __clang__
 #    define ATTRIBUTES	_target_attribute("aes,crc,sha3")
    /*
-    * With gcc, arch=armv8.2-a is needed for the sha3 intrinsics, unless the
-    * default target is armv8.3-a or later in which case it must be omitted.
-    * armv8.3-a or later can be detected by checking for __ARM_FEATURE_JCVT.
+    * With gcc 13.1 and earlier (before gcc commit 73d3bc348190 or 9aac37ab8a7b,
+    * "aarch64: Remove architecture dependencies from intrinsics"),
+    * arch=armv8.2-a is needed for the sha3 intrinsics, unless the default
+    * target is armv8.3-a or later in which case it must be omitted.  armv8.3-a
+    * or later can be detected by checking for __ARM_FEATURE_JCVT.
     */
-#  elif defined(__ARM_FEATURE_JCVT)
+#  elif GCC_PREREQ(13, 2) || defined(__ARM_FEATURE_JCVT)
 #    define ATTRIBUTES	_target_attribute("+crypto,+crc,+sha3")
 #  else
 #    define ATTRIBUTES	_target_attribute("arch=armv8.2-a+crypto+crc+sha3")


### PR DESCRIPTION
Resolves https://github.com/ebiggers/libdeflate/issues/369