### PR TITLE
lib/arm/cpu_features: add fallback definition for DP_INSTRUCTIONS_AVAILABLE

### DIFF
--- a/lib/arm/cpu_features.c
+++ b/lib/arm/cpu_features.c
@@ -170,6 +170,10 @@ static u32 query_arm_cpu_features(void)
 
 #include <windows.h>
 
+#ifndef PF_ARM_V82_DP_INSTRUCTIONS_AVAILABLE /* added in Windows SDK 20348 */
+#  define PF_ARM_V82_DP_INSTRUCTIONS_AVAILABLE 43
+#endif
+
 static u32 query_arm_cpu_features(void)
 {
 	u32 features = ARM_CPU_FEATURE_NEON;
@@ -178,11 +182,8 @@ static u32 query_arm_cpu_features(void)
 		features |= ARM_CPU_FEATURE_PMULL;
 	if (IsProcessorFeaturePresent(PF_ARM_V8_CRC32_INSTRUCTIONS_AVAILABLE))
 		features |= ARM_CPU_FEATURE_CRC32;
-
-#ifdef PF_ARM_V82_DP_INSTRUCTIONS_AVAILABLE
 	if (IsProcessorFeaturePresent(PF_ARM_V82_DP_INSTRUCTIONS_AVAILABLE))
 		features |= ARM_CPU_FEATURE_DOTPROD;
-#endif
 
 	/* FIXME: detect SHA3 support too. */
 


### PR DESCRIPTION
This constant has a fixed and documented value, and IsProcessorFeaturePresent() behaves as expected when passed an unknown value, so it makes sense to provide a fallback definition.