### PR TITLE
support decompress by stream（block by block）

### DIFF
--- a/lib/decompress_template.h
+++ b/lib/decompress_template.h
@@ -41,13 +41,24 @@
 #  define EXTRACT_VARBITS8(word, count)	((word) & BITMASK((u8)(count)))
 #endif
 
+#define _DEF_bitstream_byte_restore() do{	\
+		bitsleft = (u8)bitsleft;			\
+		SAFETY_CHECK(overread_count <= (bitsleft >> 3));	\
+		in_next -= (bitsleft >> 3) - overread_count; } while(0)
+#define _DEF_bitstream_byte_align() do{	\
+		_DEF_bitstream_byte_restore();  \
+		overread_count = 0;	\
+		bitbuf = 0;			\
+		bitsleft = 0; } while(0)
+
 static ATTRIBUTES MAYBE_UNUSED enum libdeflate_result
 FUNCNAME(struct libdeflate_decompressor * restrict d,
 	 const void * restrict in, size_t in_nbytes,
-	 void * restrict out, size_t out_nbytes_avail,
-	 size_t *actual_in_nbytes_ret, size_t *actual_out_nbytes_ret)
+	 void * restrict out, size_t in_dict_nbytes, size_t out_nbytes_avail,
+	 size_t *actual_in_nbytes_ret,size_t *actual_out_nbytes_ret,
+	 enum libdeflate_decompress_stop_by stop_type,int* is_final_block_ret)
 {
-	u8 *out_next = out;
+	u8 *out_next = ((u8 *)out)+in_dict_nbytes;
 	u8 * const out_end = out_next + out_nbytes_avail;
 	u8 * const out_fastloop_end =
 		out_end - MIN(out_nbytes_avail, FASTLOOP_MAX_BYTES_WRITTEN);
@@ -57,9 +68,9 @@ FUNCNAME(struct libdeflate_decompressor * restrict d,
 	const u8 * const in_end = in_next + in_nbytes;
 	const u8 * const in_fastloop_end =
 		in_end - MIN(in_nbytes, FASTLOOP_MAX_BYTES_READ);
-	bitbuf_t bitbuf = 0;
+	bitbuf_t bitbuf = d->bitbuf_back;
 	bitbuf_t saved_bitbuf;
-	u32 bitsleft = 0;
+	u32 bitsleft = d->bitsleft_back;
 	size_t overread_count = 0;
 
 	bool is_final_block;
@@ -68,6 +79,8 @@ FUNCNAME(struct libdeflate_decompressor * restrict d,
 	unsigned num_offset_syms;
 	bitbuf_t litlen_tablemask;
 	u32 entry;
+
+	_decompress_block_init(d);
 
 next_block:
 	/* Starting to read the next block */
@@ -261,12 +274,7 @@ next_block:
 		 * that have been refilled but not actually consumed yet (not
 		 * counting overread bytes, which don't increment 'in_next').
 		 */
-		bitsleft = (u8)bitsleft;
-		SAFETY_CHECK(overread_count <= (bitsleft >> 3));
-		in_next -= (bitsleft >> 3) - overread_count;
-		overread_count = 0;
-		bitbuf = 0;
-		bitsleft = 0;
+		_DEF_bitstream_byte_align();
 
 		SAFETY_CHECK(in_end - in_next >= 4);
 		len = get_unaligned_le16(in_next);
@@ -739,31 +747,49 @@ generic_loop:
 
 block_done:
 	/* Finished decoding a block */
+	if (is_final_block)
+		_DEF_bitstream_byte_align();
 
-	if (!is_final_block)
-		goto next_block;
+	switch (stop_type){
+		case LIBDEFLATE_STOP_BY_FINAL_BLOCK:{
+			if (!is_final_block)
+				goto next_block;
+		} break;
+		case LIBDEFLATE_STOP_BY_ANY_BLOCK:{
+			// stop, not next block
+		} break;
+		case LIBDEFLATE_STOP_BY_ANY_BLOCK_AND_FULL_INPUT:{
+			if (in_next-((((u8)bitsleft)>>3)-overread_count)<in_end)
+				goto next_block;
+		} break;
+		case LIBDEFLATE_STOP_BY_ANY_BLOCK_AND_FULL_OUTPUT:{
+			if (out_next<out_end)
+				goto next_block;
+		} break;
+		case LIBDEFLATE_STOP_BY_ANY_BLOCK_AND_FULL_OUTPUT_AND_IN_BYTE_ALIGN:{
+			if ((out_next<out_end)|((bitsleft&7)!=0))
+				goto next_block;
+		} break;
+	}
 
 	/* That was the last block. */
-
-	bitsleft = (u8)bitsleft;
-
-	/*
-	 * If any of the implicit appended zero bytes were consumed (not just
-	 * refilled) before hitting end of stream, then the data is bad.
-	 */
-	SAFETY_CHECK(overread_count <= (bitsleft >> 3));
+	if (is_final_block_ret)
+		*is_final_block_ret=is_final_block;
+	if (!is_final_block){
+		_DEF_bitstream_byte_restore();
+		//backup for next block
+		d->bitsleft_back=bitsleft&7;
+		d->bitbuf_back=bitbuf&((1<<(bitsleft&7))-1);
+	}
 
 	/* Optionally return the actual number of bytes consumed. */
 	if (actual_in_nbytes_ret) {
-		/* Don't count bytes that were refilled but not consumed. */
-		in_next -= (bitsleft >> 3) - overread_count;
-
 		*actual_in_nbytes_ret = in_next - (u8 *)in;
 	}
 
 	/* Optionally return the actual number of bytes written. */
 	if (actual_out_nbytes_ret) {
-		*actual_out_nbytes_ret = out_next - (u8 *)out;
+		*actual_out_nbytes_ret = out_next - (((u8 *)out)+in_dict_nbytes);
 	} else {
 		if (out_next != out_end)
 			return LIBDEFLATE_SHORT_OUTPUT;

--- a/lib/deflate_decompress.c
+++ b/lib/deflate_decompress.c
@@ -669,12 +669,19 @@ struct libdeflate_decompressor {
 	/* used only during build_decode_table() */
 	u16 sorted_syms[DEFLATE_MAX_NUM_SYMS];
 
+    u32         bitsleft_back;
+	bitbuf_t    bitbuf_back;
 	bool static_codes_loaded;
 	unsigned litlen_tablebits;
 
 	/* The free() function for this struct, chosen at allocation time */
 	free_func_t free_func;
 };
+
+static forceinline void _decompress_block_init(struct libdeflate_decompressor* d){
+	d->bitbuf_back=0;
+	d->bitsleft_back=0;
+}
 
 /*
  * Build a table for fast decoding of symbols from a Huffman code.  As input,
@@ -1072,8 +1079,9 @@ build_offset_decode_table(struct libdeflate_decompressor *d,
 typedef enum libdeflate_result (*decompress_func_t)
 	(struct libdeflate_decompressor * restrict d,
 	 const void * restrict in, size_t in_nbytes,
-	 void * restrict out, size_t out_nbytes_avail,
-	 size_t *actual_in_nbytes_ret, size_t *actual_out_nbytes_ret);
+	 void * restrict out, size_t in_dict_nbytes, size_t out_nbytes_avail,
+	 size_t *actual_in_nbytes_ret,size_t *actual_out_nbytes_ret,
+	 enum libdeflate_decompress_stop_by stop_type,int* is_final_block_ret);
 
 #define FUNCNAME deflate_decompress_default
 #undef ATTRIBUTES
@@ -1096,8 +1104,9 @@ typedef enum libdeflate_result (*decompress_func_t)
 static enum libdeflate_result
 dispatch_decomp(struct libdeflate_decompressor *d,
 		const void *in, size_t in_nbytes,
-		void *out, size_t out_nbytes_avail,
-		size_t *actual_in_nbytes_ret, size_t *actual_out_nbytes_ret);
+		void *out, size_t in_dict_nbytes, size_t out_nbytes_avail,
+		size_t *actual_in_nbytes_ret,size_t *actual_out_nbytes_ret,
+		enum libdeflate_decompress_stop_by stop_type,int* is_final_block_ret);
 
 static volatile decompress_func_t decompress_impl = dispatch_decomp;
 
@@ -1105,8 +1114,9 @@ static volatile decompress_func_t decompress_impl = dispatch_decomp;
 static enum libdeflate_result
 dispatch_decomp(struct libdeflate_decompressor *d,
 		const void *in, size_t in_nbytes,
-		void *out, size_t out_nbytes_avail,
-		size_t *actual_in_nbytes_ret, size_t *actual_out_nbytes_ret)
+		void *out, size_t in_dict_nbytes, size_t out_nbytes_avail,
+		size_t *actual_in_nbytes_ret,size_t *actual_out_nbytes_ret,
+		enum libdeflate_decompress_stop_by stop_type,int* is_final_block_ret)
 {
 	decompress_func_t f = arch_select_decompress_func();
 
@@ -1114,13 +1124,41 @@ dispatch_decomp(struct libdeflate_decompressor *d,
 		f = DEFAULT_IMPL;
 
 	decompress_impl = f;
-	return f(d, in, in_nbytes, out, out_nbytes_avail,
-		 actual_in_nbytes_ret, actual_out_nbytes_ret);
+	return f(d, in, in_nbytes, out,in_dict_nbytes, out_nbytes_avail,
+		 	 actual_in_nbytes_ret, actual_out_nbytes_ret, stop_type, is_final_block_ret);
 }
 #else
 /* The best implementation is statically known, so call it directly. */
 #  define decompress_impl DEFAULT_IMPL
 #endif
+
+
+LIBDEFLATEAPI enum libdeflate_result
+libdeflate_deflate_decompress_block(struct libdeflate_decompressor *d,
+				 const void *in_part, size_t in_part_nbytes_bound,
+				 void *out_block_with_in_dict,size_t in_dict_nbytes, size_t out_block_nbytes,
+				 size_t *actual_in_nbytes_ret,size_t *actual_out_nbytes_ret,
+				 enum libdeflate_decompress_stop_by stop_type,int* is_final_block_ret){
+	return decompress_impl(d, in_part, in_part_nbytes_bound, 
+						   out_block_with_in_dict, in_dict_nbytes, out_block_nbytes,
+						   actual_in_nbytes_ret, actual_out_nbytes_ret, stop_type, is_final_block_ret);
+}
+
+LIBDEFLATEAPI uint16_t libdeflate_deflate_decompress_get_state(struct libdeflate_decompressor *d){
+	ASSERT(d->bitsleft_back<=7);
+	ASSERT(d->bitbuf_back==(uint16_t)(d->bitbuf_back<<3>>3));
+	return (d->bitbuf_back<<3) | d->bitsleft_back;
+}
+
+LIBDEFLATEAPI void libdeflate_deflate_decompress_set_state(struct libdeflate_decompressor *d,uint16_t state){
+	d->bitsleft_back=state&7;
+	d->bitbuf_back=state>>3;
+}
+
+LIBDEFLATEAPI void
+libdeflate_deflate_decompress_block_reset(struct libdeflate_decompressor *d){
+    _decompress_block_init(d);
+}
 
 /*
  * This is the main DEFLATE decompression routine.  See libdeflate.h for the
@@ -1137,8 +1175,10 @@ libdeflate_deflate_decompress_ex(struct libdeflate_decompressor *d,
 				 size_t *actual_in_nbytes_ret,
 				 size_t *actual_out_nbytes_ret)
 {
-	return decompress_impl(d, in, in_nbytes, out, out_nbytes_avail,
-			       actual_in_nbytes_ret, actual_out_nbytes_ret);
+	_decompress_block_init(d);
+	return decompress_impl(d,in,in_nbytes,out,0,out_nbytes_avail,
+						   actual_in_nbytes_ret,actual_out_nbytes_ret,
+						   LIBDEFLATE_STOP_BY_FINAL_BLOCK,NULL);
 }
 
 LIBDEFLATEAPI enum libdeflate_result
@@ -1147,9 +1187,10 @@ libdeflate_deflate_decompress(struct libdeflate_decompressor *d,
 			      void *out, size_t out_nbytes_avail,
 			      size_t *actual_out_nbytes_ret)
 {
-	return libdeflate_deflate_decompress_ex(d, in, in_nbytes,
-						out, out_nbytes_avail,
-						NULL, actual_out_nbytes_ret);
+	_decompress_block_init(d);
+	return decompress_impl(d,in,in_nbytes,out,0,out_nbytes_avail,
+						   NULL,actual_out_nbytes_ret,
+						   LIBDEFLATE_STOP_BY_FINAL_BLOCK,NULL);
 }
 
 LIBDEFLATEAPI struct libdeflate_decompressor *

--- a/lib/gzip_overhead.h
+++ b/lib/gzip_overhead.h
@@ -1,0 +1,20 @@
+#ifndef LIB_GZIP_OVERHEAD_H
+#define LIB_GZIP_OVERHEAD_H
+
+#include "lib_common.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+size_t libdeflate_gzip_compress_head(unsigned compression_level,size_t in_nbytes,
+			 void *out, size_t out_nbytes_avail);
+size_t libdeflate_gzip_compress_foot(uint32_t in_crc, size_t in_nbytes,
+			 void *out, size_t out_nbytes_avail);
+int libdeflate_gzip_decompress_head(const void *in, size_t in_nbytes,
+			 size_t *actual_in_nbytes_ret);
+int libdeflate_gzip_decompress_foot(const void *in, size_t in_nbytes,
+			 u32* saved_crc,u32* saved_uncompress_nbytes,
+			 size_t *actual_in_nbytes_ret);
+#ifdef __cplusplus
+}
+#endif
+#endif /* LIB_GZIP_OVERHEAD_H */

--- a/programs/CMakeLists.txt
+++ b/programs/CMakeLists.txt
@@ -42,7 +42,7 @@ endif()
 
 # Build and install libdeflate-gzip and its alias libdeflate-gunzip.
 if(LIBDEFLATE_BUILD_GZIP)
-    add_executable(libdeflate-gzip gzip.c)
+    add_executable(libdeflate-gzip gzip.c gzip_decompress_by_stream.c)
     target_link_libraries(libdeflate-gzip PRIVATE libdeflate_prog_utils)
     install(TARGETS libdeflate-gzip DESTINATION ${CMAKE_INSTALL_BINDIR})
     if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.14")

--- a/programs/gzip.c
+++ b/programs/gzip.c
@@ -26,6 +26,7 @@
  */
 
 #include "prog_util.h"
+#include "gzip_decompress_by_stream.h"
 
 #include <errno.h>
 #include <sys/stat.h>
@@ -185,124 +186,6 @@ out:
 }
 
 static int
-do_decompress(struct libdeflate_decompressor *decompressor,
-	      struct file_stream *in, struct file_stream *out,
-	      const struct options *options)
-{
-	const u8 *compressed_data = in->mmap_mem;
-	size_t compressed_size = in->mmap_size;
-	void *uncompressed_data = NULL;
-	size_t uncompressed_size;
-	size_t max_uncompressed_size;
-	size_t actual_in_nbytes;
-	size_t actual_out_nbytes;
-	enum libdeflate_result result;
-	int ret = 0;
-
-	if (compressed_size < GZIP_MIN_OVERHEAD ||
-	    compressed_data[0] != GZIP_ID1 ||
-	    compressed_data[1] != GZIP_ID2) {
-		if (options->force && options->to_stdout)
-			return full_write(out, compressed_data, compressed_size);
-		msg("%"TS": not in gzip format", in->name);
-		return -1;
-	}
-
-	/*
-	 * Use the ISIZE field as a hint for the decompressed data size.  It may
-	 * need to be increased later, however, because the file may contain
-	 * multiple gzip members and the particular ISIZE we happen to use may
-	 * not be the largest; or the real size may be >= 4 GiB, causing ISIZE
-	 * to overflow.  In any case, make sure to allocate at least one byte.
-	 */
-	uncompressed_size =
-		get_unaligned_le32(&compressed_data[compressed_size - 4]);
-	if (uncompressed_size == 0)
-		uncompressed_size = 1;
-
-	/*
-	 * DEFLATE cannot expand data more than 1032x, so there's no need to
-	 * ever allocate a buffer more than 1032 times larger than the
-	 * compressed data.  This is a fail-safe, albeit not a very good one, if
-	 * ISIZE becomes corrupted on a small file.  (The 1032x number comes
-	 * from each 2 bits generating a 258-byte match.  This is a hard upper
-	 * bound; the real upper bound is slightly smaller due to overhead.)
-	 */
-	if (compressed_size <= SIZE_MAX / 1032)
-		max_uncompressed_size = compressed_size * 1032;
-	else
-		max_uncompressed_size = SIZE_MAX;
-
-	do {
-		if (uncompressed_data == NULL) {
-			uncompressed_size = MIN(uncompressed_size,
-						max_uncompressed_size);
-			uncompressed_data = xmalloc(uncompressed_size);
-			if (uncompressed_data == NULL) {
-				msg("%"TS": file is probably too large to be "
-				    "processed by this program", in->name);
-				ret = -1;
-				goto out;
-			}
-		}
-
-		result = libdeflate_gzip_decompress_ex(decompressor,
-						       compressed_data,
-						       compressed_size,
-						       uncompressed_data,
-						       uncompressed_size,
-						       &actual_in_nbytes,
-						       &actual_out_nbytes);
-
-		if (result == LIBDEFLATE_INSUFFICIENT_SPACE) {
-			if (uncompressed_size >= max_uncompressed_size) {
-				msg("Bug in libdeflate_gzip_decompress_ex(): data expanded too much!");
-				ret = -1;
-				goto out;
-			}
-			if (uncompressed_size * 2 <= uncompressed_size) {
-				msg("%"TS": file corrupt or too large to be "
-				    "processed by this program", in->name);
-				ret = -1;
-				goto out;
-			}
-			uncompressed_size *= 2;
-			free(uncompressed_data);
-			uncompressed_data = NULL;
-			continue;
-		}
-
-		if (result != LIBDEFLATE_SUCCESS) {
-			msg("%"TS": file corrupt or not in gzip format",
-			    in->name);
-			ret = -1;
-			goto out;
-		}
-
-		if (actual_in_nbytes == 0 ||
-		    actual_in_nbytes > compressed_size ||
-		    actual_out_nbytes > uncompressed_size) {
-			msg("Bug in libdeflate_gzip_decompress_ex(): impossible actual_nbytes value!");
-			ret = -1;
-			goto out;
-		}
-
-		if (!options->test) {
-			ret = full_write(out, uncompressed_data, actual_out_nbytes);
-			if (ret != 0)
-				goto out;
-		}
-
-		compressed_data += actual_in_nbytes;
-		compressed_size -= actual_in_nbytes;
-
-	} while (compressed_size != 0);
-out:
-	free(uncompressed_data);
-	return ret;
-}
-
-static int
 stat_file(struct file_stream *in, stat_t *stbuf, bool allow_hard_links)
 {
 	if (tfstat(in->fd, stbuf) != 0) {
@@ -448,14 +331,12 @@ decompress_file(struct libdeflate_decompressor *decompressor, const tchar *path,
 	if (ret != 0)
 		goto out_close_in;
 
-	/* TODO: need a streaming-friendly solution */
-	ret = map_file_contents(&in, stbuf.st_size);
-	if (ret != 0)
+    ret = gzip_decompress_by_stream(decompressor, &in, stbuf.st_size, (options->test?0:&out), 
+									NULL, NULL);
+	if (ret != 0){
+		msg("\nERROR: gzip_decompress_by_stream() error code %d\n\n",ret);
 		goto out_close_out;
-
-	ret = do_decompress(decompressor, &in, &out, options);
-	if (ret != 0)
-		goto out_close_out;
+	}
 
 	if (oldpath != NULL && newpath != NULL)
 		restore_metadata(&out, newpath, &stbuf);

--- a/programs/gzip_decompress_by_stream.c
+++ b/programs/gzip_decompress_by_stream.c
@@ -1,0 +1,180 @@
+/*
+ * gzip_decompress_by_stream.c
+ * added decompress by stream, 2023 housisong
+ */
+#include <assert.h>
+#include <string.h> //memcpy
+#include "../lib/gzip_overhead.h"
+#include "../lib/gzip_constants.h"
+#include "gzip_decompress_by_stream.h"
+
+#define             kDictSize    (1<<15)  //MATCHFINDER_WINDOW_SIZE
+static const size_t kMaxDeflateBlockSize   = 301000; //default starting value, if input DeflateBlockSize greater than this, then will auto increase;  
+static const size_t kMaxDeflateBlockSize_min =1024*4;
+static const size_t kMaxDeflateBlockSize_max = ((~(size_t)0)-kDictSize)/2;
+#define _check(v,_ret_errCode) do { if (!(v)) {err_code=_ret_errCode; goto _out; } } while (0)
+#define _check_d(_d_ret) _check(_d_ret==LIBDEFLATE_SUCCESS, _d_ret)
+
+typedef ssize_t (*xread_t)(struct file_stream *strm, void *buf, size_t count);
+typedef int (*full_write_t)(struct file_stream *strm, const void *buf, size_t count);
+
+#define _read_code_from_file() do{  \
+    size_t read_len=code_cur;       \
+    memmove(code_buf,code_buf+code_cur,code_buf_size-code_cur); \
+    code_cur=0; \
+    if (in_cur+read_len>in_size){   \
+        code_buf_size-=read_len-(size_t)(in_size-in_cur);       \
+        read_len=in_size-in_cur;    \
+    }           \
+    _check(read_len==xread_proc(in,code_buf+code_buf_size-read_len,read_len),    \
+           LIBDEFLATE_DESTREAM_READ_FILE_ERROR);    \
+    in_cur+=read_len;               \
+} while(0)
+
+static inline size_t _limitMaxDefBSize(size_t maxDeflateBlockSize){
+    if (unlikely(maxDeflateBlockSize<kMaxDeflateBlockSize_min)) return kMaxDeflateBlockSize_min;
+    if (unlikely(maxDeflateBlockSize>kMaxDeflateBlockSize_max)) return kMaxDeflateBlockSize_max;
+    return maxDeflateBlockSize;
+}
+
+static int _gzip_decompress_by_stream(struct libdeflate_decompressor *d,
+				struct file_stream *in, u64 in_size,struct file_stream *out,
+                xread_t xread_proc,full_write_t full_write_proc,
+				u64* _actual_in_nbytes_ret,u64* _actual_out_nbytes_ret){
+    int err_code=0;
+    u8* data_buf=0;
+    u8* code_buf=0;
+    u8* _dict_buf_back=0;
+    u64    in_cur=0;
+    u64    out_cur=0;
+    size_t curDeflateBlockSize=kMaxDeflateBlockSize;
+    size_t curBlockSize=_limitMaxDefBSize(curDeflateBlockSize);
+    size_t data_buf_size=curBlockSize+kDictSize;
+    size_t code_buf_size=(curBlockSize<in_size)?curBlockSize:in_size;
+    size_t data_cur=kDictSize; //empty
+    size_t code_cur=code_buf_size; //empty
+    size_t actual_in_nbytes_ret;
+    uint32_t data_crc=0;
+    int is_final_block_ret=0;
+    int ret;
+
+    data_buf=(u8*)malloc(data_buf_size);
+    _check(data_buf!=0, LIBDEFLATE_DESTREAM_MEM_ALLOC_ERROR);
+    code_buf=(u8*)malloc(code_buf_size);
+    _check(code_buf!=0, LIBDEFLATE_DESTREAM_MEM_ALLOC_ERROR);
+
+    _read_code_from_file();
+    {//gzip head
+        ret=libdeflate_gzip_decompress_head(code_buf,code_buf_size-code_cur,&actual_in_nbytes_ret);
+        _check_d(ret);
+        code_cur+=actual_in_nbytes_ret;
+    }
+
+    while(1){
+        //     [ ( dict ) |     dataBuf                 ]              [            codeBuf              ]
+        //     ^              ^         ^               ^              ^                     ^           ^
+        //  data_buf       out_cur   data_cur     data_buf_size     code_buf              code_cur code_buf_size
+        size_t kLimitDataSize=curBlockSize/2+kDictSize;
+        size_t kLimitCodeSize=code_buf_size/2;
+    __datas_prepare:
+        if (is_final_block_ret||(data_cur>kLimitDataSize)){//save data to out file
+            if (out)
+                _check(0==full_write_proc(out,data_buf+kDictSize,data_cur-kDictSize), LIBDEFLATE_DESTREAM_WRITE_FILE_ERROR);
+            data_crc=libdeflate_crc32(data_crc,data_buf+kDictSize,data_cur-kDictSize);
+            out_cur+=data_cur-kDictSize;
+            if (is_final_block_ret)
+                break;
+            memmove(data_buf,data_buf+data_cur-kDictSize,kDictSize);//dict data for next block
+            data_cur=kDictSize;
+        }
+        if (code_cur>kLimitCodeSize)
+            _read_code_from_file();
+
+        size_t actual_out_nbytes_ret;
+        const size_t dec_state=libdeflate_deflate_decompress_get_state(d);
+        ret=libdeflate_deflate_decompress_block(d,code_buf+code_cur,code_buf_size-code_cur,
+                data_buf+data_cur-kDictSize,kDictSize,data_buf_size-data_cur,
+                &actual_in_nbytes_ret,&actual_out_nbytes_ret,
+                LIBDEFLATE_STOP_BY_ANY_BLOCK,&is_final_block_ret);
+        if (ret!=LIBDEFLATE_SUCCESS){
+            if ((in_cur==in_size)&&(ret!=LIBDEFLATE_INSUFFICIENT_SPACE))
+                _check_d(ret);
+            kLimitDataSize=kDictSize;
+            kLimitCodeSize=0;
+            if ((data_cur>kDictSize)||((code_cur>0)&&(in_cur<in_size))) { //need more datas & retry
+                //ok
+            }else if (curDeflateBlockSize<kMaxDeflateBlockSize_max){//need increase buf size & retry
+                curDeflateBlockSize=(curDeflateBlockSize*2<kMaxDeflateBlockSize_max)?curDeflateBlockSize*2:kMaxDeflateBlockSize_max;
+                size_t _curBlockSize=_limitMaxDefBSize(curDeflateBlockSize);
+                size_t _data_buf_size=_curBlockSize+kDictSize;
+                const size_t loaded_in_size=(code_buf_size-code_cur);
+                const u64 rem_in_size=loaded_in_size+(in_size-in_cur);
+                size_t _code_buf_size=(_curBlockSize<rem_in_size)?_curBlockSize:rem_in_size;
+                curBlockSize=_curBlockSize;
+                {
+                    assert(data_cur==kDictSize);
+                    if (_dict_buf_back==0){
+                        _dict_buf_back=(u8*)malloc(kDictSize);
+                        _check(_dict_buf_back!=0, LIBDEFLATE_DESTREAM_MEM_ALLOC_ERROR);
+                    }
+                    memcpy(_dict_buf_back,data_buf,kDictSize);
+                    free(data_buf); data_buf=0;
+                }
+                if (_code_buf_size>code_buf_size){
+                    u8* _code_buf=(u8*)realloc(code_buf,_code_buf_size);
+                    _check(_code_buf!=0, LIBDEFLATE_DESTREAM_MEM_ALLOC_ERROR);
+                    code_buf=_code_buf; _code_buf=0;
+                    memcpy(code_buf+_code_buf_size-loaded_in_size,code_buf+code_cur,loaded_in_size);
+                    code_cur+=_code_buf_size-code_buf_size;
+                    code_buf_size=_code_buf_size;
+                }
+                {
+                    data_buf=(u8*)malloc(_data_buf_size);
+                    _check(data_buf!=0, LIBDEFLATE_DESTREAM_MEM_ALLOC_ERROR);
+                    memcpy(data_buf,_dict_buf_back,kDictSize);
+                    data_buf_size=_data_buf_size;
+                }
+            }else{ //decompress fail, can't increase buf
+                _check_d(ret);
+            }
+            libdeflate_deflate_decompress_set_state(d,dec_state);
+            goto __datas_prepare; //retry by more datas
+        }
+        //decompress ok
+        code_cur+=actual_in_nbytes_ret;
+        data_cur+=actual_out_nbytes_ret;
+    }
+    
+    {//gzip foot
+        uint32_t saved_crc;
+        uint32_t saved_uncompress_nbytes;
+        if (code_cur+GZIP_FOOTER_SIZE>code_buf_size)
+            _read_code_from_file();
+        ret=libdeflate_gzip_decompress_foot(code_buf+code_cur,code_buf_size-code_cur,
+                &saved_crc,&saved_uncompress_nbytes,&actual_in_nbytes_ret);
+        _check_d(ret);
+        code_cur+=actual_in_nbytes_ret;
+
+        _check(saved_crc==data_crc, LIBDEFLATE_DESTREAM_DATA_CRC_ERROR);
+        _check(saved_uncompress_nbytes==(u32)out_cur, LIBDEFLATE_DESTREAM_DATA_SIZE_ERROR);
+    }
+
+    if (_actual_in_nbytes_ret)
+        *_actual_in_nbytes_ret=(in_cur-(size_t)(code_buf_size-code_cur));
+    if (_actual_out_nbytes_ret)
+        *_actual_out_nbytes_ret=out_cur;
+
+_out:
+    if (data_buf) free(data_buf);
+    if (code_buf) free(code_buf);
+    if (_dict_buf_back) free(_dict_buf_back);
+    return err_code;
+}
+
+
+int gzip_decompress_by_stream(struct libdeflate_decompressor *d,
+							  struct file_stream *in, u64 in_size, struct file_stream *out,
+							  u64* actual_in_nbytes_ret,u64* actual_out_nbytes_ret){
+	return _gzip_decompress_by_stream(d,in,in_size,out,xread,full_write,
+									  actual_in_nbytes_ret,actual_out_nbytes_ret);
+}

--- a/programs/gzip_decompress_by_stream.h
+++ b/programs/gzip_decompress_by_stream.h
@@ -1,0 +1,30 @@
+/*
+ * gzip_decompress_by_stream.h
+ * added decompress by stream, 2023 housisong
+ */
+#ifndef PROGRAMS_PROG_GZIP_DECOMPRESS_STREAM_H
+#define PROGRAMS_PROG_GZIP_DECOMPRESS_STREAM_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "prog_util.h"
+
+enum libdeflate_destream_result{
+	LIBDEFLATE_DESTREAM_MEM_ALLOC_ERROR =20,
+	LIBDEFLATE_DESTREAM_READ_FILE_ERROR,
+	LIBDEFLATE_DESTREAM_WRITE_FILE_ERROR,
+	LIBDEFLATE_DESTREAM_DATA_CRC_ERROR,
+	LIBDEFLATE_DESTREAM_DATA_SIZE_ERROR,
+};
+
+//decompress gzip by stream
+//  'out','actual_in_nbytes_ret','actual_out_nbytes_ret' can NULL;
+//	return value is libdeflate_result or libdeflate_destream_result.
+int gzip_decompress_by_stream(struct libdeflate_decompressor *decompressor,
+							  struct file_stream *in, u64 in_size, struct file_stream *out,
+							  u64* actual_in_nbytes_ret,u64* actual_out_nbytes_ret);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* PROGRAMS_PROG_GZIP_DECOMPRESS_STREAM_H */


### PR DESCRIPTION
Added several lower-level APIs with minor source code changes, to support decompress block by block;    
And updated the gzip cmdline by new APIs, the memory usage when decompress will be greatly reduced, usually <1MB!    
Also, because it needs to support any .gz format (not just libdeflate), the decompress buffer will automatically adjust the size to fit the maximum block size.   
   
Because decompressor reused a small memory, the cache hit ratio will be greatly improved, resulting in an increase in decompress speed;    
In my multiple test cases, it was able to get 20%--50% faster.
   
( I used libdeflate for my multiple actual projects and make a lot of feature changes; Hopefully commit some useful changes back to libdeflate. )