### PR TITLE
lib/x86/crc32: target pclmul,sse4.1 instead of pclmul

### DIFF
--- a/lib/x86/cpu_features.c
+++ b/lib/x86/cpu_features.c
@@ -140,7 +140,12 @@ void libdeflate_init_x86_cpu_features(void)
 		family += (a >> 20) & 0xff;
 	if (d & (1 << 26))
 		features |= X86_CPU_FEATURE_SSE2;
-	if (c & (1 << 1))
+	/*
+	 * No known CPUs have pclmulqdq without sse4.1, so in practice code
+	 * targeting pclmulqdq can use sse4.1 instructions.  But to be safe,
+	 * explicitly check for both the pclmulqdq and sse4.1 bits.
+	 */
+	if ((c & (1 << 1)) && (c & (1 << 19)))
 		features |= X86_CPU_FEATURE_PCLMULQDQ;
 	if (c & (1 << 27))
 		xcr0 = read_xcr(0);

--- a/lib/x86/cpu_features.h
+++ b/lib/x86/cpu_features.h
@@ -108,7 +108,8 @@ static inline u32 get_x86_cpu_features(void) { return 0; }
 #  define HAVE_SSE2_NATIVE		0
 #endif
 
-#if defined(__PCLMUL__) || (defined(_MSC_VER) && defined(__AVX2__))
+#if (defined(__PCLMUL__) && defined(__SSE4_1__)) || \
+	(defined(_MSC_VER) && defined(__AVX2__))
 #  define HAVE_PCLMULQDQ(features)	1
 #else
 #  define HAVE_PCLMULQDQ(features)	((features) & X86_CPU_FEATURE_PCLMULQDQ)


### PR DESCRIPTION
In practice, all CPUs that support PCLMULQDQ also support SSE4.1:

    Intel: Westmere and later + Silvermont and later
    AMD: Bulldozer and later

Therefore, make crc32_x86_pclmulqdq() use SSE4.1 instructions.

To be safe, add an explicit check for SSE4.1 support.  Though as per the above, this is unnecessary in practice (as far as I can tell).