### PR TITLE
lib/x86: do not specify no-evex512 when main target has evex512

### DIFF
--- a/lib/x86/cpu_features.h
+++ b/lib/x86/cpu_features.h
@@ -165,7 +165,8 @@ static inline u32 get_x86_cpu_features(void) { return 0; }
 #  define HAVE_AVXVNNI(features)	((features) & X86_CPU_FEATURE_AVXVNNI)
 #endif
 
-#if GCC_PREREQ(14, 0) || CLANG_PREREQ(18, 0, 18000000)
+#if (GCC_PREREQ(14, 0) || CLANG_PREREQ(18, 0, 18000000)) \
+	&& !defined(__EVEX512__) /* avoid subtracting the evex512 feature */
 #  define EVEX512	",evex512"	/* needed to override potential -mno-evex512 */
 #  define NO_EVEX512	",no-evex512"	/* needed for AVX10/256 compatibility */
 #else


### PR DESCRIPTION
Avoid build errors when building with -march=native on a system that supports AVX512.

Fixes: 972e73490640 ("lib/x86: Specify evex512 and no-evex512 when appropriate")