### PR TITLE
ci.yml: stop testing Visual Studio + ARM32

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,11 +139,8 @@ jobs:
     name: Build (Windows, Visual Studio ${{matrix.toolset}}, ${{matrix.platform}})
     strategy:
       matrix:
-        platform: [ARM64, ARM]
+        platform: [ARM64]
         toolset: [v143, ClangCL]
-        exclude: # Exclude unsupported combinations
-        - platform: ARM
-          toolset: ClangCL
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This combination no longer builds due the following error:

    error MSB8037: The Windows SDK version 10.0.26100.0 for Desktop C++ ARM Apps was not found.