### PR TITLE
Fix type mismatch in deflate_compress.c

### DIFF
--- a/lib/deflate_compress.c
+++ b/lib/deflate_compress.c
@@ -2633,10 +2633,10 @@ deflate_compress_lazy_generic(struct libdeflate_compressor * restrict c,
 						  in_max_block_end - in_next,
 						  c->max_search_depth);
 		do {
-			unsigned cur_len;
-			unsigned cur_offset;
-			unsigned next_len;
-			unsigned next_offset;
+			u32 cur_len;
+			u32 cur_offset;
+			u32 next_len;
+			u32 next_offset;
 
 			/*
 			 * Recalculate the minimum match length if it hasn't


### PR DESCRIPTION
# In short
The type mismatch between `u32` and `unsigned int` in 
`deflate_compress.c` caused a weird compilation failure on arm-none-eabi-gcc 14.2.0 when compiling for ARM32.

# Details
```
lib/deflate_compress.c: In function 'deflate_compress_lazy_generic':
lib/deflate_compress.c:2666:49: error: passing argument 9 of 'hc_matchfinder_longest_match' from incompatible pointer type [-Wincompatible-pointer-types]
  2666 |                                                 &cur_offset);
       |                                                 ^~~~~~~~~~~
       |                                                 |
       |                                                 unsigned int *
In file included from lib/deflate_compress.c:166:
hc_matchfinder.h:191:42: note: expected 'u32 * const' {aka 'long unsigned int * const'} but argument is of type 'unsigned int *'
   191 |                              u32 * const offset_ret)
       |                              ~~~~~~~~~~~~^~~~~~~~~~
``` 
The type `u32` is somehow recognized as **`long unsigned int`** whose pointer is incompatible with `unsigned int`. Simply changing the types of the 4 variables to `u32` addresses the issue (hopefully this won't break anything).