### PR TITLE
lib/deflate_compress: use u32 for match length and offsets

### DIFF
--- a/lib/matchfinder_common.h
+++ b/lib/matchfinder_common.h
@@ -175,11 +175,11 @@ lz_hash(u32 seq, unsigned num_bits)
  * Return the number of bytes at @matchptr that match the bytes at @strptr, up
  * to a maximum of @max_len.  Initially, @start_len bytes are matched.
  */
-static forceinline unsigned
+static forceinline u32
 lz_extend(const u8 * const strptr, const u8 * const matchptr,
-	  const unsigned start_len, const unsigned max_len)
+	  const u32 start_len, const u32 max_len)
 {
-	unsigned len = start_len;
+	u32 len = start_len;
 	machine_word_t v_word;
 
 	if (UNALIGNED_ACCESS_IS_FAST) {


### PR DESCRIPTION
As reported at https://github.com/ebiggers/libdeflate/pull/416, deflate_compress.c is passing a pointer to unsigned int to a function that takes a pointer to u32.  This is not compatible with unsigned int and u32 being different sizes, and was also reported to cause a compiler warning with arm-none-eabi-gcc (despite the types being the same size there).

Let's just consistently use u32 for match lengths and offsets instead of unsigned int.  This is suboptimal when sizeof(unsigned int) == 2, but that case seems to be fairly dead and libdeflate has never worked there anyway.