### PR TITLE
lib/x86/cpu_features.h: drop evex512 on gcc-16

### DIFF
--- a/lib/x86/adler32_impl.h
+++ b/lib/x86/adler32_impl.h
@@ -82,7 +82,7 @@
  */
 #  define adler32_x86_avx512_vl256_vnni	adler32_x86_avx512_vl256_vnni
 #  define SUFFIX				   _avx512_vl256_vnni
-#  define ATTRIBUTES		_target_attribute("avx512bw,avx512vl,avx512vnni" NO_EVEX512)
+#  define ATTRIBUTES		_target_attribute("avx512bw,avx512vl,avx512vnni")
 #  define VL			32
 #  define USE_VNNI		1
 #  define USE_AVX512		1
@@ -94,7 +94,7 @@
  */
 #  define adler32_x86_avx512_vl512_vnni	adler32_x86_avx512_vl512_vnni
 #  define SUFFIX				   _avx512_vl512_vnni
-#  define ATTRIBUTES		_target_attribute("avx512bw,avx512vnni" EVEX512)
+#  define ATTRIBUTES		_target_attribute("avx512bw,avx512vnni")
 #  define VL			64
 #  define USE_VNNI		1
 #  define USE_AVX512		1

--- a/lib/x86/cpu_features.h
+++ b/lib/x86/cpu_features.h
@@ -165,7 +165,7 @@ static inline u32 get_x86_cpu_features(void) { return 0; }
 #  define HAVE_AVXVNNI(features)	((features) & X86_CPU_FEATURE_AVXVNNI)
 #endif
 
-#if (GCC_PREREQ(14, 0) || CLANG_PREREQ(18, 0, 18000000)) \
+#if ((GCC_PREREQ(14, 0) && !(GCC_PREREQ(16, 0))) || CLANG_PREREQ(18, 0, 18000000)) \
 	&& !defined(__EVEX512__) /* avoid subtracting the evex512 feature */
 #  define EVEX512	",evex512"	/* needed to override potential -mno-evex512 */
 #  define NO_EVEX512	",no-evex512"

--- a/lib/x86/cpu_features.h
+++ b/lib/x86/cpu_features.h
@@ -165,15 +165,6 @@ static inline u32 get_x86_cpu_features(void) { return 0; }
 #  define HAVE_AVXVNNI(features)	((features) & X86_CPU_FEATURE_AVXVNNI)
 #endif
 
-#if ((GCC_PREREQ(14, 0) && !(GCC_PREREQ(16, 0))) || CLANG_PREREQ(18, 0, 18000000)) \
-	&& !defined(__EVEX512__) /* avoid subtracting the evex512 feature */
-#  define EVEX512	",evex512"	/* needed to override potential -mno-evex512 */
-#  define NO_EVEX512	",no-evex512"
-#else
-#  define EVEX512	""
-#  define NO_EVEX512	""
-#endif
-
 #endif /* ARCH_X86_32 || ARCH_X86_64 */
 
 #endif /* LIB_X86_CPU_FEATURES_H */

--- a/lib/x86/crc32_impl.h
+++ b/lib/x86/crc32_impl.h
@@ -104,7 +104,7 @@ static const u8 MAYBE_UNUSED shift_tab[48] = {
  */
 #  define crc32_x86_vpclmulqdq_avx512_vl256  crc32_x86_vpclmulqdq_avx512_vl256
 #  define SUFFIX				      _vpclmulqdq_avx512_vl256
-#  define ATTRIBUTES		_target_attribute("vpclmulqdq,pclmul,avx512bw,avx512vl" NO_EVEX512)
+#  define ATTRIBUTES		_target_attribute("vpclmulqdq,pclmul,avx512bw,avx512vl")
 #  define VL			32
 #  define USE_AVX512		1
 #  include "crc32_pclmul_template.h"
@@ -117,7 +117,7 @@ static const u8 MAYBE_UNUSED shift_tab[48] = {
  */
 #  define crc32_x86_vpclmulqdq_avx512_vl512  crc32_x86_vpclmulqdq_avx512_vl512
 #  define SUFFIX				      _vpclmulqdq_avx512_vl512
-#  define ATTRIBUTES		_target_attribute("vpclmulqdq,pclmul,avx512bw,avx512vl" EVEX512)
+#  define ATTRIBUTES		_target_attribute("vpclmulqdq,pclmul,avx512bw,avx512vl")
 #  define VL			64
 #  define USE_AVX512		1
 #  include "crc32_pclmul_template.h"


### PR DESCRIPTION
gcc-16 `master` branch dropped support for `evex512` as:
    https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=c052a6f4a1c803cb92147ff98fb91cf3511e0856

As a result libdeflate build started failing as:

    In file included from /build/source/lib/adler32.c:28:
    /build/source/lib/x86/adler32_template.h:135:12: error: attribute 'target' argument 'no-evex512' is unknown
      135 | ADD_SUFFIX(reduce_to_32bits)(vec_t v_s1, vec_t v_s2, u32 *s1_p, u32 *s2_p)
          |            ^~~~~~~~~~~~~~~~

The change adds upper build to `evex512` for `gcc`.