### PR TITLE
Replace libdeflate-java, which has no production release, with jlibdeflate...

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ following bindings:
 * C#: [LibDeflate.NET](https://github.com/jzebedee/LibDeflate.NET)
 * Delphi: [libdeflate-pas](https://github.com/zedxxx/libdeflate-pas)
 * Go: [go-libdeflate](https://github.com/4kills/go-libdeflate)
-* Java: [libdeflate-java](https://github.com/astei/libdeflate-java)
+* Java: [jlibdeflate](https://github.com/fulcrumgenomics/jlibdeflate)
 * Julia: [LibDeflate.jl](https://github.com/jakobnissen/LibDeflate.jl)
 * Nim: [libdeflate-nim](https://github.com/gemesa/libdeflate-nim)
 * Perl: [Gzip::Libdeflate](https://github.com/benkasminbullock/gzip-libdeflate)


### PR DESCRIPTION
…in the README.md.

Unfortunately libdeflate-java, while a good start:
- Has never had a production release
- Does not support MacOS at all, and does not support linux/aarch64
- Has not been touched in 2+ years

I have just released [jlibdeflate](https://github.com/fulcrumgenomics/jlibdeflate) 0.1.0 (maven release [here](https://central.sonatype.com/artifact/com.fulcrumgenomics/jlibdeflate) under the MIT license, with intent to actively support it.  jlibdeflate has support for windows/x86_64, linux/x86_64, linux/aarch64, mac/x86_64, and mac/aarch64.  Because there is production release, documentation can also be easily [found online](https://javadoc.io/doc/com.fulcrumgenomics/jlibdeflate/latest/com/fulcrumgenomics/jlibdeflate/package-summary.html).

