### PR TITLE
lib/arm/cpu_features: prefer PMULL CRC-32 on Linux Neoverse V-class

### DIFF
--- a/lib/arm/cpu_features.c
+++ b/lib/arm/cpu_features.c
@@ -54,6 +54,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 
@@ -130,6 +131,51 @@ static u32 query_arm_cpu_features(void)
 	return features;
 }
 
+#ifdef ARCH_ARM64
+/*
+ * Return whether cpu0's MIDR_EL1 identifies one of the Arm Neoverse
+ * V-class server cores (V1 / V2 / V3 / V3AE).  MIDR_EL1 is exposed
+ * unprivileged via sysfs (added in Linux 4.7).  Reading cpu0 only is fine
+ * in practice: no Neoverse V-class server SKU has shipped as part of a
+ * big.LITTLE cluster.  Any failure (file missing, read error, parse
+ * failure, unrecognized CPU) returns false.
+ */
+static bool arm64_cpu_is_neoverse_v_class(void)
+{
+	int fd;
+	char buf[32];
+	ssize_t n;
+	unsigned long midr;
+	u32 part;
+
+	fd = open("/sys/devices/system/cpu/cpu0/regs/identification/midr_el1",
+		  O_RDONLY);
+	if (fd < 0)
+		return false;
+	do {
+		n = read(fd, buf, sizeof(buf) - 1);
+	} while (n < 0 && errno == EINTR);
+	close(fd);
+	if (n <= 0)
+		return false;
+	buf[n] = '\0';
+	midr = strtoul(buf, NULL, 0); /* sysfs prints "0x%016llx\n" */
+
+	/* MIDR_EL1: [31:24]=Implementer, [15:4]=PartNum. */
+	if (((midr >> 24) & 0xff) != 0x41) /* Implementer must be Arm Ltd. */
+		return false;
+	part = (midr >> 4) & 0xfff;
+	switch (part) {
+	case 0xd40: /* Neoverse V1   (e.g. AWS Graviton 3) */
+	case 0xd4f: /* Neoverse V2   (e.g. AWS Graviton 4) */
+	case 0xd83: /* Neoverse V3AE */
+	case 0xd84: /* Neoverse V3 */
+		return true;
+	}
+	return false;
+}
+#endif /* ARCH_ARM64 */
+
 #elif defined(__APPLE__)
 /* On Apple platforms, arm64 CPU features can be detected via sysctlbyname(). */
 
@@ -202,24 +248,40 @@ static const struct cpu_feature arm_cpu_feature_table[] = {
 	{ARM_CPU_FEATURE_DOTPROD,	"dotprod"},
 };
 
+/*
+ * Whether to set ARM_CPU_FEATURE_PREFER_PMULL on this CPU.  This is the
+ * right choice on CPUs whose pmull pipes have more aggregate throughput
+ * than the crc32 unit -- in measured cases by a wide margin: the Apple M
+ * series sustains ~68 GB/s on pmull vs ~25 GB/s on crc32 (M1), and the Arm
+ * Neoverse V class sustains ~40 GB/s vs ~22 GB/s (Graviton 4 / V2).
+ *
+ * We detect Apple at compile time, and Neoverse V-class cores at runtime
+ * via MIDR_EL1 on Linux.  Elsewhere we leave this unset, and the dispatcher
+ * picks the crc32-instruction path which is the right default for most
+ * other modern ARM CPUs.
+ */
+static bool arm_cpu_prefers_pmull(void)
+{
+#if defined(__APPLE__) && TARGET_OS_OSX
+	return true;
+#elif defined(__linux__) && defined(ARCH_ARM64)
+	if (arm64_cpu_is_neoverse_v_class())
+		return true;
+#endif
+#ifdef TEST_SUPPORT__DO_NOT_USE
+	return true;
+#endif
+	return false;
+}
+
 volatile u32 libdeflate_arm_cpu_features = 0;
 
 void libdeflate_init_arm_cpu_features(void)
 {
 	u32 features = query_arm_cpu_features();
 
-	/*
-	 * On the Apple M1 processor, crc32 instructions max out at about 25.5
-	 * GB/s in the best case of using a 3-way or greater interleaved chunked
-	 * implementation, whereas a pmull-based implementation achieves 68 GB/s
-	 * provided that the stride length is large enough (about 10+ vectors
-	 * with eor3, or 12+ without).
-	 *
-	 * Assume that crc32 instructions are preferable in other cases.
-	 */
-#if (defined(__APPLE__) && TARGET_OS_OSX) || defined(TEST_SUPPORT__DO_NOT_USE)
-	features |= ARM_CPU_FEATURE_PREFER_PMULL;
-#endif
+	if (arm_cpu_prefers_pmull())
+		features |= ARM_CPU_FEATURE_PREFER_PMULL;
 
 	disable_cpu_features_for_testing(&features, arm_cpu_feature_table,
 					 ARRAY_LEN(arm_cpu_feature_table));


### PR DESCRIPTION
This is my first attempt at a real PR for `libdeflate` - I've done my best to follow established patterns in the repo and tailor this PR to fit in with previous work, but I am *very* open to feedback both on the PR content itself, and any further additional testing/benchmarking/etc. that you would like to see.  I should also note that I used AI (Claude) extensively in researching and documenting this change.

## Summary

Enables libdeflate's existing 12-way PMULL CRC-32 fold (`crc32_arm_pmullx12_crc_eor3` /
`crc32_arm_pmullx12_crc`) on AWS Graviton 3, Graviton 4, and other Arm Neoverse V-class
server cores running Linux. Until now this code path was gated by
`ARM_CPU_FEATURE_PREFER_PMULL`, which was only set when compiled for Apple macOS. On
AWS Graviton 4 (Neoverse V2) this raises **CRC-32 throughput from ~22 GB/s to ~40 GB/s
(1.80×)**.

The fast paths themselves are unchanged — this PR is purely a CPU feature detection / dispatch
decision.

## Implementation

On Linux arm64, read MIDR_EL1 via the unprivileged sysfs entry
`/sys/devices/system/cpu/cpu0/regs/identification/midr_el1` (exposed by the kernel
since [Linux 4.7][linux-midr-sysfs], July 2016) and check the Implementer (Arm Ltd. =
`0x41`) and PartNum fields. If the PartNum matches the conservative whitelist of
Arm Neoverse V-class cores, set `ARM_CPU_FEATURE_PREFER_PMULL`. The whitelist is:

| PartNum | Core | Notable SKU |
|--------:|---|---|
| `0xd40` | Neoverse V1 | AWS Graviton 3 |
| `0xd4f` | Neoverse V2 | AWS Graviton 4 |
| `0xd83` | Neoverse V3AE | — |
| `0xd84` | Neoverse V3 | — |

All four PartNum values were cross-checked against
[`arch/arm64/include/asm/cputype.h`][kernel-cputype] in torvalds/linux.

[linux-midr-sysfs]: https://github.com/torvalds/linux/commit/f6e763b93a
[kernel-cputype]: https://github.com/torvalds/linux/blob/master/arch/arm64/include/asm/cputype.h

The whole policy is wrapped in a small `arm_cpu_prefers_pmull()` helper modeled
structurally on `allow_512bit_vectors()` in `lib/x86/cpu_features.c`:

```c
static bool arm_cpu_prefers_pmull(void)
{
#if defined(__APPLE__) && TARGET_OS_OSX
    return true;
#elif defined(__linux__) && defined(ARCH_ARM64)
    if (arm64_cpu_is_neoverse_v_class())
        return true;
#endif
#ifdef TEST_SUPPORT__DO_NOT_USE
    return true;
#endif
    return false;
}
```

## Performance

All measurements on **AWS c8g.large (Neoverse V2, single dedicated vCPU)**, with
`programs/checksum -t -s 1048576` on a 1 GiB random buffer, 5 runs each.

| variant | dispatched function | MB/s | vs baseline |
|---|---|---:|---:|
| baseline (master) | `crc32_arm_crc_pmullcombine` | 21,860 | 1.00× |
| this PR | `crc32_arm_pmullx12_crc_eor3` | **39,420** | **1.80×** |
| this PR, SHA3 disabled\* | `crc32_arm_pmullx12_crc` | 33,650 | 1.54× |

\* Forced via `LIBDEFLATE_DISABLE_CPU_FEATURES=sha3` to verify the non-eor3 path is
still well above baseline. This is why we don't require SHA3 in the runtime gate
— the dispatcher in `lib/arm/crc32_impl.h` picks the eor3 variant when SHA3 is
also present and falls back to `pmullx12_crc` (still 1.54× over the old default)
otherwise.

### End-to-end (gzip-format)

On the same machine with `programs/benchmark -6 -g -s 65280` on a 247MB input file the end-to-end decompress gain is modest:

| level | baseline dec MB/s | this PR dec MB/s | Δ |
|---|---:|---:|---:|
| 1 | 709 | 719 | +1.4% |
| 3 | 729 | 739 | +1.4% |
| 6 | 720 | 730 | +1.4% |
| 9 | 702 | 710 | +1.1% |

The input file for this test was a FASTQ file containing DNA sequencing reads from a short read sequencer; the block size for compression mirrors the 64kb limit used the BGZF format widely used in genomics (the field I work in).

## Testing

- `scripts/run_tests.sh regular` passes on the c8g instance, exercising all seven
  `LIBDEFLATE_DISABLE_CPU_FEATURES` combinations from `regular_test` (including
  `prefer_pmull` disabled and re-enabled) and four cross-compatibility gzip /
  gunzip permutations against `/bin/gzip`.
- All eight `programs/test_*` binaries pass on both c8g and on macOS arm64 (M2),
  confirming the Apple compile-time path still works.
- Existing CI (Debian bookworm aarch64 GCC + clang) will exercise the
  `pmullx12_crc[_eor3]` path through the unconditional `TEST_SUPPORT__DO_NOT_USE`
  branch in `arm_cpu_prefers_pmull()`, the same way it has since `c1926a4`.

## Design notes / anticipated questions

**Why not just check HWCAP for SHA3+PMULL+CRC32 instead of MIDR?** HWCAP advertises
ISA presence, not microarchitecture identity. The PMULL-vs-CRC32 throughput
asymmetry is a microarchitectural property — Cortex-A78 and Neoverse N1 have
PMULL+CRC32 too, but their relative throughput doesn't justify switching dispatch.
This is the same reason `lib/x86/cpu_features.c::allow_512bit_vectors()` checks
family/model and not just AVX-512 presence.

**Why a whitelist and not a calibration probe?** No existing libdeflate code path
uses a runtime calibration probe; `allow_512bit_vectors()` is the closest
precedent and uses a hardcoded model whitelist. A probe would add startup latency
and a new test surface for negligible benefit on the four known parts.

**Why only Neoverse V1/V2/V3/V3AE and not Cortex-X1 etc.?** Conservative. Cortex-X
cores are mobile-tuned and the PMULL/CRC32 ratio hasn't been validated there;
Neoverse N1 (Graviton 2) and N2 (Graviton 3E) have narrower PMULL pipes that
don't outperform their CRC32 instructions. The whitelist can be extended in
follow-ups as additional cores are measured.

**What if the sysfs file isn't readable?** The function returns `false` on every
error path (file missing, read error, parse failure, unrecognized implementer or
part). The dispatcher then stays on whatever path it would have selected before —
the existing `crc32_arm_crc_pmullcombine` on Linux/server arm64, or the
appropriate fallback elsewhere. There is no behavior change for any CPU outside
the whitelist or any system where sysfs isn't available.

**Why cpu0 only?** The kernel ABI notes MIDR_EL1 isn't necessarily uniform across
CPUs on heterogeneous systems, but no Neoverse V-class server SKU has ever shipped
as part of a big.LITTLE configuration, and the HWCAP-based feature checks are
system-safe by construction. For current real-world hardware, cpu0 is
representative.
