### PR TITLE
C standard update and CI fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,15 +118,15 @@ jobs:
     - uses: microsoft/setup-msbuild@v2
     - run: vcpkg install zlib:${{matrix.vcpkg}}
     - run: >
-        echo C:\vcpkg\packages\zlib_${{matrix.vcpkg}}\bin
+        echo C:\vcpkg\installed\${{matrix.vcpkg}}\bin
         | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     # Note: as per the CMake documentation, DESTDIR is unsupported on Windows.
     - run: >
         cmake -B build -G "${{matrix.gen}}" -T ${{matrix.toolset}}
         -A ${{matrix.vs}} -DLIBDEFLATE_BUILD_TESTS=1
         -DCMAKE_C_FLAGS="/W4 /WX /DLIBDEFLATE_ENABLE_ASSERTIONS"
-        -DZLIB_LIBRARY=C:\vcpkg\packages\zlib_${{matrix.vcpkg}}\lib\zlib.lib
-        -DZLIB_INCLUDE_DIR=C:\vcpkg\packages\zlib_${{matrix.vcpkg}}\include
+        -DZLIB_LIBRARY=C:\vcpkg\installed\${{matrix.vcpkg}}\lib\z.lib
+        -DZLIB_INCLUDE_DIR=C:\vcpkg\installed\${{matrix.vcpkg}}\include
         -DCMAKE_INSTALL_PREFIX=build\install
     - run: cmake --build build --verbose --config Debug
     - run: cmake --install build --verbose --config Debug

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,7 @@ if(NOT LIBDEFLATE_USER_SET_RELEASE_FLAGS)
     set(CMAKE_C_FLAGS_RELEASE "-O2 -DNDEBUG"
         CACHE STRING "C compiler flags for release builds" FORCE)
 endif()
-set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD 11)
 if(NOT MSVC)
     check_c_compiler_flag(-Wdeclaration-after-statement HAVE_WDECLARATION_AFTER_STATEMENT)
     check_c_compiler_flag(-Wimplicit-fallthrough HAVE_WIMPLICIT_FALLTHROUGH)

--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ If you are doing a freestanding build with `-ffreestanding`, you must add
 
 - gcc: v4.9 and later
 - clang: v3.9 and later (upstream), Xcode 8 and later (Apple)
-- MSVC: Visual Studio 2015 and later
-- Other compilers: any other C99-compatible compiler should work, though if your
+- MSVC: Visual Studio 2019 version 16.8 and later
+- Other compilers: any other C11-compatible compiler should work, though if your
   compiler pretends to be gcc, clang, or MSVC, it needs to be sufficiently
   compatible with the compiler it pretends to be.
 

--- a/common_defs.h
+++ b/common_defs.h
@@ -212,20 +212,6 @@ typedef size_t machine_word_t;
 #  define NORETURN
 #endif
 
-/*
- * restrict - hint that writes only occur through the given pointer.
- *
- * Don't use MSVC's __restrict, since it has nonstandard behavior.
- * Standard restrict is okay, if it is supported.
- */
-#if !defined(__STDC_VERSION__) || (__STDC_VERSION__ < 201112L)
-#  if defined(__GNUC__) || defined(__clang__)
-#    define restrict		__restrict__
-#  else
-#    define restrict
-#  endif
-#endif /* else assume 'restrict' is usable as-is */
-
 /* likely(expr) - hint that an expression is usually true */
 #if defined(__GNUC__) || __has_builtin(__builtin_expect)
 #  define likely(expr)		__builtin_expect(!!(expr), 1)

--- a/common_defs.h
+++ b/common_defs.h
@@ -159,8 +159,8 @@ typedef size_t machine_word_t;
 #endif
 #ifdef _MSC_VER
 #  define MSVC_PREREQ(version)	(_MSC_VER >= (version))
-#  if !MSVC_PREREQ(1900)
-#    error "MSVC versions older than Visual Studio 2015 are no longer supported"
+#  if !MSVC_PREREQ(1928)
+#    error "MSVC versions older than Visual Studio 2019 v16.8 are no longer supported"
 #  endif
 #else
 #  define MSVC_PREREQ(version)	0

--- a/lib/deflate_decompress.c
+++ b/lib/deflate_decompress.c
@@ -1094,18 +1094,18 @@ typedef enum libdeflate_result (*decompress_func_t)
 
 #ifdef arch_select_decompress_func
 static enum libdeflate_result
-dispatch_decomp(struct libdeflate_decompressor *d,
-		const void *in, size_t in_nbytes,
-		void *out, size_t out_nbytes_avail,
+dispatch_decomp(struct libdeflate_decompressor * restrict d,
+		const void * restrict in, size_t in_nbytes,
+		void * restrict out, size_t out_nbytes_avail,
 		size_t *actual_in_nbytes_ret, size_t *actual_out_nbytes_ret);
 
 static volatile decompress_func_t decompress_impl = dispatch_decomp;
 
 /* Choose the best implementation at runtime. */
 static enum libdeflate_result
-dispatch_decomp(struct libdeflate_decompressor *d,
-		const void *in, size_t in_nbytes,
-		void *out, size_t out_nbytes_avail,
+dispatch_decomp(struct libdeflate_decompressor * restrict d,
+		const void * restrict in, size_t in_nbytes,
+		void * restrict out, size_t out_nbytes_avail,
 		size_t *actual_in_nbytes_ret, size_t *actual_out_nbytes_ret)
 {
 	decompress_func_t f = arch_select_decompress_func();

--- a/lib/x86/adler32_impl.h
+++ b/lib/x86/adler32_impl.h
@@ -82,7 +82,7 @@
  */
 #  define adler32_x86_avx512_vl256_vnni	adler32_x86_avx512_vl256_vnni
 #  define SUFFIX				   _avx512_vl256_vnni
-#  define ATTRIBUTES		_target_attribute("avx512bw,avx512vl,avx512vnni")
+#  define ATTRIBUTES		_target_attribute("avx512bw,avx512vl,avx512vnni" NO_EVEX512)
 #  define VL			32
 #  define USE_VNNI		1
 #  define USE_AVX512		1
@@ -94,7 +94,7 @@
  */
 #  define adler32_x86_avx512_vl512_vnni	adler32_x86_avx512_vl512_vnni
 #  define SUFFIX				   _avx512_vl512_vnni
-#  define ATTRIBUTES		_target_attribute("avx512bw,avx512vnni")
+#  define ATTRIBUTES		_target_attribute("avx512bw,avx512vnni" EVEX512)
 #  define VL			64
 #  define USE_VNNI		1
 #  define USE_AVX512		1

--- a/lib/x86/cpu_features.h
+++ b/lib/x86/cpu_features.h
@@ -165,6 +165,15 @@ static inline u32 get_x86_cpu_features(void) { return 0; }
 #  define HAVE_AVXVNNI(features)	((features) & X86_CPU_FEATURE_AVXVNNI)
 #endif
 
+#if ((CLANG_PREREQ(18, 0, 18000000) && !CLANG_PREREQ(19, 0, 19000000))) \
+	&& !defined(__EVEX512__) /* avoid subtracting the evex512 feature */
+#  define EVEX512	",evex512"	/* needed to override potential -mno-evex512 */
+#  define NO_EVEX512	",no-evex512"
+#else
+#  define EVEX512	""
+#  define NO_EVEX512	""
+#endif
+
 #endif /* ARCH_X86_32 || ARCH_X86_64 */
 
 #endif /* LIB_X86_CPU_FEATURES_H */

--- a/lib/x86/crc32_impl.h
+++ b/lib/x86/crc32_impl.h
@@ -104,7 +104,7 @@ static const u8 MAYBE_UNUSED shift_tab[48] = {
  */
 #  define crc32_x86_vpclmulqdq_avx512_vl256  crc32_x86_vpclmulqdq_avx512_vl256
 #  define SUFFIX				      _vpclmulqdq_avx512_vl256
-#  define ATTRIBUTES		_target_attribute("vpclmulqdq,pclmul,avx512bw,avx512vl")
+#  define ATTRIBUTES		_target_attribute("vpclmulqdq,pclmul,avx512bw,avx512vl" NO_EVEX512)
 #  define VL			32
 #  define USE_AVX512		1
 #  include "crc32_pclmul_template.h"
@@ -117,7 +117,7 @@ static const u8 MAYBE_UNUSED shift_tab[48] = {
  */
 #  define crc32_x86_vpclmulqdq_avx512_vl512  crc32_x86_vpclmulqdq_avx512_vl512
 #  define SUFFIX				      _vpclmulqdq_avx512_vl512
-#  define ATTRIBUTES		_target_attribute("vpclmulqdq,pclmul,avx512bw,avx512vl")
+#  define ATTRIBUTES		_target_attribute("vpclmulqdq,pclmul,avx512bw,avx512vl" EVEX512)
 #  define VL			64
 #  define USE_AVX512		1
 #  include "crc32_pclmul_template.h"


### PR DESCRIPTION
* Upgrade CMAKE_C_STANDARD to C11
* common_defs.h: remove fallback definition of 'restrict'
* deflate_decompress.c: add restrict qualifiers to dispatch_decomp()
* ci.yml: Update vcpkg zlib path
* lib/x86: Bring back evex512 and no-evex512 for clang 18
